### PR TITLE
KTO-587

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
                    :jvm-opts ["-Dport=3006"]}
              :updater {:jvm-opts ["-Dmode=updater" "-Dport=3006"]}
              :test {:dependencies [[ring/ring-mock "0.3.2"]
-                                   [kouta-indeksoija-service "0.2.1-KTO-587-v2-SNAPSHOT"]
+                                   [kouta-indeksoija-service "0.2.1-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT" :classifier "tests"]
                                    [org.mockito/mockito-core "2.28.2"]
@@ -54,7 +54,7 @@
                     :injections [(require '[clj-test-utils.elasticsearch-mock-utils :as utils])
                                  (utils/global-elasticsearch-fixture)]}
              :ci-test {:dependencies [[ring/ring-mock "0.3.2"]
-                                      [kouta-indeksoija-service "0.2.1-KTO-587-v2-SNAPSHOT"]
+                                      [kouta-indeksoija-service "0.2.1-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT" :classifier "tests"]
                                       [org.mockito/mockito-core "2.28.2"]

--- a/project.clj
+++ b/project.clj
@@ -46,19 +46,19 @@
                    :jvm-opts ["-Dport=3006"]}
              :updater {:jvm-opts ["-Dmode=updater" "-Dport=3006"]}
              :test {:dependencies [[ring/ring-mock "0.3.2"]
-                                   [kouta-indeksoija-service "0.1.21-KTO-587-SNAPSHOT"]
+                                   [kouta-indeksoija-service "0.2.1-KTO-587-v2-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT" :classifier "tests"]
                                    [org.mockito/mockito-core "2.28.2"]
-                                   [oph/clj-test-utils "0.2.5-SNAPSHOT"]]
+                                   [oph/clj-test-utils "0.2.6-SNAPSHOT"]]
                     :injections [(require '[clj-test-utils.elasticsearch-mock-utils :as utils])
                                  (utils/global-elasticsearch-fixture)]}
              :ci-test {:dependencies [[ring/ring-mock "0.3.2"]
-                                      [kouta-indeksoija-service "0.1.21-KTO-587-SNAPSHOT"]
+                                      [kouta-indeksoija-service "0.2.1-KTO-587-v2-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT" :classifier "tests"]
                                       [org.mockito/mockito-core "2.28.2"]
-                                      [oph/clj-test-utils "0.2.5-SNAPSHOT"]]
+                                      [oph/clj-test-utils "0.2.6-SNAPSHOT"]]
                        :injections [(require '[clj-test-utils.elasticsearch-mock-utils :as utils])
                                     (utils/global-elasticsearch-fixture)]
                        :jvm-opts ["-Dlog4j.configurationFile=test/resources/log4j2.properties" "-Dconf=ci-configuration/konfo-backend.edn"]}

--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
                    :jvm-opts ["-Dport=3006"]}
              :updater {:jvm-opts ["-Dmode=updater" "-Dport=3006"]}
              :test {:dependencies [[ring/ring-mock "0.3.2"]
-                                   [kouta-indeksoija-service "0.1.20-SNAPSHOT"]
+                                   [kouta-indeksoija-service "0.1.21-KTO-587-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT" :classifier "tests"]
                                    [org.mockito/mockito-core "2.28.2"]
@@ -54,7 +54,7 @@
                     :injections [(require '[clj-test-utils.elasticsearch-mock-utils :as utils])
                                  (utils/global-elasticsearch-fixture)]}
              :ci-test {:dependencies [[ring/ring-mock "0.3.2"]
-                                      [kouta-indeksoija-service "0.1.20-SNAPSHOT"]
+                                      [kouta-indeksoija-service "0.1.21-KTO-587-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "0.19-SNAPSHOT" :classifier "tests"]
                                       [org.mockito/mockito-core "2.28.2"]

--- a/src/konfo_backend/search/query.clj
+++ b/src/konfo_backend/search/query.clj
@@ -58,7 +58,7 @@
 (defn- bool
   [keyword lng constraints]
   (cond-> {}
-          (not-blank? keyword)       (assoc :must {:match {(->lng-keyword "hits.terms.%s" lng) {:query (lower-case keyword) :operator "and"}}})
+          (not-blank? keyword)       (assoc :must {:match {(->lng-keyword "hits.terms.%s" lng) {:query (lower-case keyword) :operator "and" :fuzziness "AUTO"}}})
           (constraints? constraints) (assoc :filter (filters constraints))))
 
 (defn query

--- a/test/konfo_backend/index/hakukohde_test.clj
+++ b/test/konfo_backend/index/hakukohde_test.clj
@@ -30,6 +30,8 @@
     (fixture/add-valintaperuste-mock valintaperusteId2 :tila "tallennettu")
 
     (fixture/add-toteutus-mock "1.2.246.562.17.000001" "1.2.246.562.13.000001")
+    (fixture/add-koulutus-mock "1.2.246.562.13.000001")
+    (fixture/add-haku-mock "1.2.246.562.29.000001")
 
     (fixture/index-oids-without-related-indices {:hakukohteet [hakukohdeOid1 hakukohdeOid2 hakukohdeOid3]})
 

--- a/test/konfo_backend/search/koulutus_search_test.clj
+++ b/test/konfo_backend/search/koulutus_search_test.clj
@@ -146,53 +146,106 @@
 
 (deftest koulutus-keyword-search
 
-  (fixture/add-koulutus-mock koulutusOid1 :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Lääketieteen koulutus")
-  (fixture/add-koulutus-mock koulutusOid2 :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Humanistinen koulutus")
-  (fixture/add-koulutus-mock koulutusOid3 :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Tietojenkäsittelytieteen koulutus")
-  (fixture/add-koulutus-mock koulutusOid4 :koulutustyyppi "amm" :tila "julkaistu" :nimi "Automaatiotekniikka")
-  (fixture/add-koulutus-mock koulutusOid5 :koulutustyyppi "amm" :tila "julkaistu" :nimi "Muusikon koulutus")
-  (fixture/add-koulutus-mock koulutusOid6 :koulutustyyppi "amm" :tile "julkaistu" :nimi "Sosiaali- ja terveysalan perustutkinto")
+  (fixture/add-koulutus-mock koulutusOid1  :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Lääketieteen koulutus")
+  (fixture/add-koulutus-mock koulutusOid2  :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Humanistinen koulutus")
+  (fixture/add-koulutus-mock koulutusOid3  :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Tietojenkäsittelytieteen koulutus")
+  (fixture/add-koulutus-mock koulutusOid4  :koulutustyyppi "amm" :tila "julkaistu" :nimi "Automaatiotekniikka")
+  (fixture/add-koulutus-mock koulutusOid5  :koulutustyyppi "amm" :tila "julkaistu" :nimi "Muusikon koulutus")
+  (fixture/add-koulutus-mock koulutusOid6  :koulutustyyppi "amm" :tile "julkaistu" :nimi "Sosiaali- ja terveysalan perustutkinto")
+  (fixture/add-koulutus-mock koulutusOid7  :koulutustyyppi "amm" :tile "julkaistu" :nimi "Maanmittausalan perustutkinto")
+  (fixture/add-koulutus-mock koulutusOid8  :koulutustyyppi "amm" :tile "julkaistu" :nimi "Pintakäsittelyalan perustutkinto")
+  (fixture/add-koulutus-mock koulutusOid9  :koulutustyyppi "amm" :tile "julkaistu" :nimi "Puhtaus- ja kiinteistöpalvelualan ammattitutkinto")
+  (fixture/add-koulutus-mock koulutusOid10 :koulutustyyppi "amm" :tile "julkaistu" :nimi "Puhevammaisten tulkkauksen erikoisammattitutkinto")
+  (fixture/add-koulutus-mock koulutusOid11 :koulutustyyppi "amm" :tile "julkaistu" :nimi "Hius- ja kauneudenhoitoalan perustutkinto")
 
   (fixture/add-toteutus-mock "1.2.246.562.17.000001" koulutusOid1 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "yo" :ammattinimikkeet [{:kieli "fi" :arvo "lääkäri"}]}))
   (fixture/add-toteutus-mock "1.2.246.562.17.000002" koulutusOid2 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "yo" :ammattinimikkeet [{:kieli "fi" :arvo "psykologi"}]}))
   (fixture/add-toteutus-mock "1.2.246.562.17.000004" koulutusOid4 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :ammattinimikkeet [{:kieli "fi" :arvo "automaatioinsinööri"}]}))
   (fixture/add-toteutus-mock "1.2.246.562.17.000005" koulutusOid5 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :asiasanat [{:kieli "fi" :arvo "musiikkioppilaitokset"}]}))
+  (fixture/add-toteutus-mock "1.2.246.562.17.000006" koulutusOid8 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :ammattinimikkeet [{:kieli "fi" :arvo "maalari"}]}))
 
-  (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 koulutusOid3 koulutusOid4 koulutusOid5 koulutusOid6]})
+  (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 koulutusOid3 koulutusOid4 koulutusOid5 koulutusOid6
+                                                             koulutusOid7 koulutusOid8 koulutusOid9 koulutusOid10 koulutusOid11]})
 
   (testing "Searching with keyword"
-   (testing "lääketiede <-> lääketieteen"
-     (is (= [koulutusOid1] (search-and-get-oids :keyword "lääketiede"))))
 
-   (comment testing "haluan opiskella lääkäriksi <-> lääkäri"
-     (is (= [koulutusOid1] (search-and-get-oids :keyword "haluan%20opiskella%20lääkäriksi"))))
+    (testing "maalari <-> Pintakäsittelyala (EI maanmittausala)"
+      (is (= [koulutusOid8] (search-and-get-oids :keyword "maalari"))))
 
-   (comment testing "musiikin opiskelu <-> muusikon koulutus"
-     (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikin%20opiskelu"))))
+    (testing "puhtaus <-> Puhtaus- ja kiinteistöpalveluala (EI puhevammaisten)"
+      (is (= [koulutusOid9] (search-and-get-oids :keyword "puhtaus"))))
 
-   (testing "humanismi <-> humanistinen"
-     (is (= [koulutusOid2] (search-and-get-oids :keyword "humanismi"))))
+    (testing "palvelu <-> Puhtaus- ja kiinteistöpalveluala"
+      (is (= [koulutusOid9] (search-and-get-oids :keyword "palvelu"))))
 
-   (comment testing "haluan opiskella psykologiaa <-> psykologi"
-     (is (= [koulutusOid2] (search-and-get-oids :keyword "haluan%20opiskella%20psykologiaa"))))
+    (testing "sosiaaliala <-> sosiaali- ja terveysala"
+      (is (= [koulutusOid6] (search-and-get-oids :keyword "sosiaaliala"))))
 
-   (testing "sosiaaliala <-> sosiaali- ja terveysala"
-     (is (= [koulutusOid6] (search-and-get-oids :keyword "sosiaaliala"))))
+    (testing "terveys <-> sosiaali- ja terveysala"
+      (is (= [koulutusOid6] (search-and-get-oids :keyword "terveys"))))
 
-   (testing "tietojenkäsittelytiede <-> tietojenkäsittelytieteen"
-     (is (= [koulutusOid3] (search-and-get-oids :keyword "tietojenkäsittelytiede"))))
+    (testing "musiikkioppilaitos <-> musiikkioppilaitokset"
+      (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikkioppilaitos"))))
 
-   (testing "musiikkioppilaitos <-> musiikkioppilaitokset" ;TODO fix-me
-     (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikkioppilaitos"))))
+    (testing "auto <-> automaatiotekniikka/automaatioinsinööri"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "auto"))))
 
-   (testing "automaatiikka <-> automaatioinsinööri"
-     (is (= [koulutusOid4] (search-and-get-oids :keyword "automaatiikka"))))
+    (testing "automaatio <-> automaatiotekniikka/automaatioinsinööri"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "auto"))))
 
-   (testing "auto"
-     (is (= [koulutusOid4] (search-and-get-oids :keyword "auto"))))
+    (testing "humanismi <-> humanistinen"
+      (is (= [koulutusOid2] (search-and-get-oids :keyword "humanismi"))))
 
-   (testing "muusikon koulutus"
-     (is (= [koulutusOid5] (search-and-get-oids :keyword "muusikon%20koulutus"))))
+    (testing "lääketiede <-> lääketieteen"
+      (is (= [koulutusOid1] (search-and-get-oids :keyword "lääketiede"))))
 
-   (comment testing "insinööri <-> automaatioinsinööri"
-     (is (= [koulutusOid4] (search-and-get-oids :keyword "insinööri"))))))
+    (testing "muusikko <-> muusikon koulutus"
+      (is (= [koulutusOid5] (search-and-get-oids :keyword "muusikko"))))
+
+    (testing "musiikki <-> musiikkioppilaitokset"
+      (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikki"))))
+
+    (testing "insinööri <-> automaatioinsinööri"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "insinööri"))))
+
+    (testing "tekniikka <-> automaatiotekniikka"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "tekniikka"))))
+
+    (testing "muusikon koulutus <-> EI muita koulutuksia"
+      (is (= [koulutusOid5] (search-and-get-oids :keyword "muusikon%20koulutus"))))
+
+    (testing "Maanmittausalan perustutkinto <-> EI muita perustutkintoja"
+      (is (= [koulutusOid7] (search-and-get-oids :keyword "maanmittausalan%20perustutkinto"))))
+
+    (testing "Maanmittaus perus <-> maanmittausalan perustutkinto"
+      (is (= [koulutusOid7] (search-and-get-oids :keyword "maanmittauS%20peruS"))))
+
+    (testing "tietojenkäsittelytiede <-> tietojenkäsittelytieteen"
+      (is (= [koulutusOid3] (search-and-get-oids :keyword "tietojenkäsittelytiede"))))
+
+    (testing "automaatiikka <-> automaatioinsinööri"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "automaatiikka"))))
+
+    (testing "hius <-> Hius- ja kauneudenhoitoalan perustutkinto"
+      (is (= [koulutusOid11] (search-and-get-oids :keyword "hius"))))
+
+    (testing "kauneudenhoito <-> Hius- ja kauneudenhoitoalan perustutkinto"
+      (is (= [koulutusOid11] (search-and-get-oids :keyword "kauneudenhoito"))))
+
+    (testing "hoito <-> Hius- ja kauneudenhoitoalan perustutkinto"
+      (is (= [koulutusOid11] (search-and-get-oids :keyword "hoito"))))
+
+    (testing "psykologia <-> Psykologi"
+      (is (= [koulutusOid2] (search-and-get-oids :keyword "psykologia"))))
+
+    (testing "lääke <-> lääketieteen"
+      (is (= [koulutusOid1] (search-and-get-oids :keyword "lääke"))))
+
+    (comment testing "haluan opiskella lääkäriksi <-> lääkäri"
+             (is (= [koulutusOid1] (search-and-get-oids :keyword "haluan%20opiskella%20lääkäriksi"))))
+
+    (comment testing "musiikin opiskelu <-> muusikon koulutus"
+             (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikin%20opiskelu"))))
+
+    (comment testing "haluan opiskella psykologiaa <-> psykologi"
+             (is (= [koulutusOid2] (search-and-get-oids :keyword "haluan%20opiskella%20psykologiaa"))))))

--- a/test/konfo_backend/search/koulutus_search_test.clj
+++ b/test/konfo_backend/search/koulutus_search_test.clj
@@ -149,7 +149,7 @@
   (fixture/add-koulutus-mock koulutusOid1  :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Lääketieteen koulutus")
   (fixture/add-koulutus-mock koulutusOid2  :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Humanistinen koulutus")
   (fixture/add-koulutus-mock koulutusOid3  :koulutustyyppi "yo"  :tila "julkaistu" :nimi "Tietojenkäsittelytieteen koulutus")
-  (fixture/add-koulutus-mock koulutusOid4  :koulutustyyppi "amm" :tila "julkaistu" :nimi "Automaatiotekniikka")
+  (fixture/add-koulutus-mock koulutusOid4  :koulutustyyppi "amm" :tila "julkaistu" :nimi "Automaatiotekniikka (ylempi AMK)")
   (fixture/add-koulutus-mock koulutusOid5  :koulutustyyppi "amm" :tila "julkaistu" :nimi "Muusikon koulutus")
   (fixture/add-koulutus-mock koulutusOid6  :koulutustyyppi "amm" :tile "julkaistu" :nimi "Sosiaali- ja terveysalan perustutkinto")
   (fixture/add-koulutus-mock koulutusOid7  :koulutustyyppi "amm" :tile "julkaistu" :nimi "Maanmittausalan perustutkinto")
@@ -157,26 +157,32 @@
   (fixture/add-koulutus-mock koulutusOid9  :koulutustyyppi "amm" :tile "julkaistu" :nimi "Puhtaus- ja kiinteistöpalvelualan ammattitutkinto")
   (fixture/add-koulutus-mock koulutusOid10 :koulutustyyppi "amm" :tile "julkaistu" :nimi "Puhevammaisten tulkkauksen erikoisammattitutkinto")
   (fixture/add-koulutus-mock koulutusOid11 :koulutustyyppi "amm" :tile "julkaistu" :nimi "Hius- ja kauneudenhoitoalan perustutkinto")
+  (fixture/add-koulutus-mock koulutusOid12 :koulutustyyppi "amm" :tile "julkaistu" :nimi "Autoalan perustutkinto")
 
   (fixture/add-toteutus-mock "1.2.246.562.17.000001" koulutusOid1 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "yo" :ammattinimikkeet [{:kieli "fi" :arvo "lääkäri"}]}))
-  (fixture/add-toteutus-mock "1.2.246.562.17.000002" koulutusOid2 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "yo" :ammattinimikkeet [{:kieli "fi" :arvo "psykologi"}]}))
-  (fixture/add-toteutus-mock "1.2.246.562.17.000004" koulutusOid4 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :ammattinimikkeet [{:kieli "fi" :arvo "automaatioinsinööri"}]}))
+  (fixture/add-toteutus-mock "1.2.246.562.17.000002" koulutusOid2 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "yo" :ammattinimikkeet [{:kieli "fi" :arvo "psykologi"}] :asiasanat [{:kieli "fi" :arvo "ammattikorkeakoulu"}]}))
+  (fixture/add-toteutus-mock "1.2.246.562.17.000004" koulutusOid4 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :ammattinimikkeet [{:kieli "fi" :arvo "automaatioinsinööri"}] :asiasanat [{:kieli "fi" :arvo "ammattioppilaitos"}]}))
   (fixture/add-toteutus-mock "1.2.246.562.17.000005" koulutusOid5 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :asiasanat [{:kieli "fi" :arvo "musiikkioppilaitokset"}]}))
   (fixture/add-toteutus-mock "1.2.246.562.17.000006" koulutusOid8 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :ammattinimikkeet [{:kieli "fi" :arvo "maalari"}]}))
+  (fixture/add-toteutus-mock "1.2.246.562.17.000007" koulutusOid12 :tila "julkaistu" :metadata (cheshire/generate-string {:tyyppi "amm" :ammattinimikkeet [{:kieli "fi" :arvo "automaalari"}]}))
+
 
   (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 koulutusOid3 koulutusOid4 koulutusOid5 koulutusOid6
-                                                             koulutusOid7 koulutusOid8 koulutusOid9 koulutusOid10 koulutusOid11]})
+                                                             koulutusOid7 koulutusOid8 koulutusOid9 koulutusOid10 koulutusOid11 koulutusOid12]})
 
   (testing "Searching with keyword"
 
     (testing "maalari <-> Pintakäsittelyala (EI maanmittausala)"
-      (is (= [koulutusOid8] (search-and-get-oids :keyword "maalari"))))
+      (is (= [koulutusOid12 koulutusOid8] (search-and-get-oids :keyword "maalari"))))
 
     (testing "puhtaus <-> Puhtaus- ja kiinteistöpalveluala (EI puhevammaisten)"
       (is (= [koulutusOid9] (search-and-get-oids :keyword "puhtaus"))))
 
     (testing "palvelu <-> Puhtaus- ja kiinteistöpalveluala"
       (is (= [koulutusOid9] (search-and-get-oids :keyword "palvelu"))))
+
+    (testing "ammattitutkinto <-> EI ammattioppilaitos tai ammattikorkeakoulu"
+      (is (= [koulutusOid10 koulutusOid9] (search-and-get-oids :keyword "ammattitutkinto"))))
 
     (testing "sosiaaliala <-> sosiaali- ja terveysala"
       (is (= [koulutusOid6] (search-and-get-oids :keyword "sosiaaliala"))))
@@ -188,10 +194,10 @@
       (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikkioppilaitos"))))
 
     (testing "auto <-> automaatiotekniikka/automaatioinsinööri"
-      (is (= [koulutusOid4] (search-and-get-oids :keyword "auto"))))
+      (is (= [koulutusOid12 koulutusOid4] (search-and-get-oids :keyword "auto"))))
 
-    (testing "automaatio <-> automaatiotekniikka/automaatioinsinööri"
-      (is (= [koulutusOid4] (search-and-get-oids :keyword "auto"))))
+    (testing "automaatio <-> automaatiotekniikka/automaatioinsinööri, EI autoalan perustutkintoa"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "automaatio"))))
 
     (testing "humanismi <-> humanistinen"
       (is (= [koulutusOid2] (search-and-get-oids :keyword "humanismi"))))
@@ -205,7 +211,13 @@
     (testing "musiikki <-> musiikkioppilaitokset"
       (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikki"))))
 
+    (testing "musikko <-> muusikko"
+      (is (= [koulutusOid5] (search-and-get-oids :keyword "musiikki"))))
+
     (testing "insinööri <-> automaatioinsinööri"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "insinööri"))))
+
+    (testing "insinöö <-> automaatioinsinööri"
       (is (= [koulutusOid4] (search-and-get-oids :keyword "insinööri"))))
 
     (testing "tekniikka <-> automaatiotekniikka"
@@ -216,6 +228,9 @@
 
     (testing "Maanmittausalan perustutkinto <-> EI muita perustutkintoja"
       (is (= [koulutusOid7] (search-and-get-oids :keyword "maanmittausalan%20perustutkinto"))))
+
+    (testing "perustutkinto maanmittaus <-> EI muita perustutkintoja"
+      (is (= [koulutusOid7] (search-and-get-oids :keyword "perustutkinto%20maanmittaus"))))
 
     (testing "Maanmittaus perus <-> maanmittausalan perustutkinto"
       (is (= [koulutusOid7] (search-and-get-oids :keyword "maanmittauS%20peruS"))))
@@ -240,6 +255,27 @@
 
     (testing "lääke <-> lääketieteen"
       (is (= [koulutusOid1] (search-and-get-oids :keyword "lääke"))))
+
+    (testing "ylemp <-> ylempi (AMK)"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "ylemp"))))
+
+    (testing "amk <-> ylempi (AMK)"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "amk"))))
+
+    (testing "psygologia <-> psykologia"
+      (is (= [koulutusOid2] (search-and-get-oids :keyword "psygologia"))))
+
+    (testing "perus <-> kaikki perustutkinnot"
+      (is (= [koulutusOid12 koulutusOid11 koulutusOid7 koulutusOid8 koulutusOid6] (search-and-get-oids :keyword "perus"))))
+
+    (testing "perututkito <-> kaikki perustutkinnot"
+      (is (= [koulutusOid12 koulutusOid11 koulutusOid7 koulutusOid8 koulutusOid6] (search-and-get-oids :keyword "perus"))))
+
+    (testing "teknikko <-> tekniikka"
+      (is (= [koulutusOid4] (search-and-get-oids :keyword "teknikko"))))
+
+    (testing "tiede <-> lääketiede ja tietojenkäsittelytiede"
+      (is (= [koulutusOid1 koulutusOid3] (search-and-get-oids :keyword "tiede"))))
 
     (comment testing "haluan opiskella lääkäriksi <-> lääkäri"
              (is (= [koulutusOid1] (search-and-get-oids :keyword "haluan%20opiskella%20lääkäriksi"))))

--- a/test/konfo_backend/search/query_test.clj
+++ b/test/konfo_backend/search/query_test.clj
@@ -6,7 +6,7 @@
 (deftest oppilaitos-query-test
   (testing "Query with keyword"
     (is (= (query "Hauska" "fi" {})
-           {:nested {:path "hits", :query {:bool {:must {:match {:hits.terms.fi {:query "hauska" :operator "and"}}}}}}})))
+           {:nested {:path "hits", :query {:bool {:must {:match {:hits.terms.fi {:query "hauska" :operator "and" :fuzziness "AUTO"}}}}}}})))
 
   (testing "Query with filters"
     (is (= (query nil "fi" {:sijainti ["kunta_091"] :koulutustyyppi ["amm", "KK"]})
@@ -15,7 +15,7 @@
 
   (testing "Query with keyword and filters"
     (is (= (query "Hauska" "fi" {:sijainti ["kunta_091"] :koulutustyyppi ["amm", "KK"]})
-           {:nested {:path "hits", :query {:bool {:must {:match {:hits.terms.fi { :query "hauska" :operator "and"}}}
+           {:nested {:path "hits", :query {:bool {:must {:match {:hits.terms.fi { :query "hauska" :operator "and" :fuzziness "AUTO"}}}
                                                   :filter [{:terms {:hits.koulutustyypit.keyword ["amm", "kk"]}}
                                                            {:term {:hits.sijainti.keyword "kunta_091"}}]}}}}))))
 

--- a/test/konfo_backend/search/search_test_tools.clj
+++ b/test/konfo_backend/search/search_test_tools.clj
@@ -13,6 +13,11 @@
 (def koulutusOid4 "1.2.246.562.13.000004")
 (def koulutusOid5 "1.2.246.562.13.000005")
 (def koulutusOid6 "1.2.246.562.13.000006")
+(def koulutusOid7 "1.2.246.562.13.000007")
+(def koulutusOid8 "1.2.246.562.13.000008")
+(def koulutusOid9 "1.2.246.562.13.000009")
+(def koulutusOid10 "1.2.246.562.13.000010")
+(def koulutusOid11 "1.2.246.562.13.000011")
 
 (def oppilaitosOid1 "1.2.246.562.10.0000011")
 (def oppilaitosOid2 "1.2.246.562.10.0000012")

--- a/test/konfo_backend/search/search_test_tools.clj
+++ b/test/konfo_backend/search/search_test_tools.clj
@@ -18,6 +18,7 @@
 (def koulutusOid9 "1.2.246.562.13.000009")
 (def koulutusOid10 "1.2.246.562.13.000010")
 (def koulutusOid11 "1.2.246.562.13.000011")
+(def koulutusOid12 "1.2.246.562.13.000012")
 
 (def oppilaitosOid1 "1.2.246.562.10.0000011")
 (def oppilaitosOid2 "1.2.246.562.10.0000012")


### PR DESCRIPTION
- Lisätty fuzzinessia koulutus- ja oppilaitoshakuihin, jota saadaan haut toimimaan paremmin ja toisaalta jotta käyttäjän tekemät pienet typot ei haittaa
- Otettu käyttöön uudempi versio kouta-indeksoijasta
- Lisätty testitapauksia koulutushaun toimivuudelle erilaisilla hakusanoilla (en jaksanut lisätä niitä oppilaitoshaulle, koska ne käyttävät samoja analyze settingsejä ja toimivat siksi siltä osin identtisesti.)
- Korjattu yps:n takia rikkoutuneita hakukohde-testejä