### PR TITLE
KTO-653

### DIFF
--- a/src/konfo_backend/core.clj
+++ b/src/konfo_backend/core.clj
@@ -165,13 +165,11 @@
       ;TODO: poista koulutuskoodi-uri, kun tuotannossa kaikilla koulutuksilla on eperuste-id
       (context "/kuvaus"
         []
-        (GET "/:koodi" [:as request]
-          :summary "Hae koulutuksen kuvaus ePerusteista koulutuskoodin tai eperuste-id:n perusteella"
-          :path-params [koodi :- String]
+        (GET "/:id" [:as request]
+          :summary "Hae koulutuksen kuvaus (ja osaamisalakuvaukset) ePerusteista eperuste-id:n perusteella"
+          :path-params [id :- String]
           :query-params [{osaamisalakuvaukset :- Boolean false}]
-          (with-access-logging request (if-let [result (if (re-matches #"[1-9][0-9]*" koodi)
-                                                         (eperuste/get-kuvaus-by-eperuste-id (read-string koodi) osaamisalakuvaukset)
-                                                         (eperuste/get-kuvaus-by-koulutuskoodi-uri koodi osaamisalakuvaukset))]
+          (with-access-logging request (if-let [result (eperuste/get-kuvaus-by-eperuste-id id osaamisalakuvaukset)]
                                          (ok result)
                                          (not-found "Not found")))))
 

--- a/src/konfo_backend/eperuste/eperuste.clj
+++ b/src/konfo_backend/eperuste/eperuste.clj
@@ -19,6 +19,6 @@
 
 (defn get-kuvaus-by-eperuste-id
   [id with-osaamisalakuvaukset?]
-  (when-let [kuvaus (some-> id eperuste-index/get :kuvaus)]
-    (cond-> {:id id :kuvaus (select-keys kuvaus [:fi :sv :en])}
+  (when-let [eperuste (some-> id eperuste-index/get)]
+    (cond-> (select-keys eperuste [:id :kuvaus :tyotehtavatJoissaVoiToimia :suorittaneenOsaaminen])
             with-osaamisalakuvaukset? (assoc :osaamisalat (osaamisalakuvaus-index/get-kuvaukset-by-eperuste-id id)))))

--- a/src/konfo_backend/eperuste/eperuste.clj
+++ b/src/konfo_backend/eperuste/eperuste.clj
@@ -4,18 +4,13 @@
 
 (defn get-eperuste-by-id
   [id]
-  (eperuste-index/get id))
+  (when-let [eperuste (eperuste-index/get id)]
+    (when (= "valmis" (:tila eperuste))
+      eperuste)))
 
 (defn get-osaamisalakuvaus-by-id
   [id]
   (osaamisalakuvaus-index/get id))
-
-(defn get-kuvaus-by-koulutuskoodi-uri
-  [koulutuskoodi-uri with-osaamisalakuvaukset?]
-  (let [kuvaus (eperuste-index/get-kuvaus-by-koulutuskoodi koulutuskoodi-uri)
-        id     (:id kuvaus)]
-    (cond-> kuvaus
-            (and with-osaamisalakuvaukset? (some? id)) (assoc :osaamisalat (osaamisalakuvaus-index/get-kuvaukset-by-eperuste-id id)))))
 
 (defn get-kuvaus-by-eperuste-id
   [id with-osaamisalakuvaukset?]

--- a/src/konfo_backend/index/eperuste.clj
+++ b/src/konfo_backend/index/eperuste.clj
@@ -10,51 +10,9 @@
 
 (def eperuste-search (partial search index))
 
-(defn- voimassa?
-  [eperuste]
-  (when-let [alkaa (:voimassaoloAlkaa eperuste)]
-    (if-let [lopppuu (:voimassaoloLoppuu eperuste)]
-      (<= alkaa (now-in-millis) lopppuu)
-      (<= alkaa (now-in-millis)))))
-
-(defn- siirtyma?
-  [eperuste]
-  (when-let [siirtyma (:siirtymaPaattyy eperuste)]
-    (<= (now-in-millis) siirtyma)))
-
-(defn- valmis?
-  [eperuste]
-  (some-> eperuste :tila (= "valmis")))
-
-(defn- get-koulutus
-  [eperuste koulutus-koodi-uri]
-  (->> eperuste
-       :koulutukset
-       (filter #(= (:koulutuskoodiUri %) koulutus-koodi-uri))
-       (first)))
-
-(defn- koulutus?
-  [eperuste koulutus-koodi-uri]
-  (not (nil? (get-koulutus eperuste koulutus-koodi-uri))))
-
 (defn get
   [id]
-  (when-let [eperuste (get-source index id)]
-    (when (and (valmis? eperuste) (or (voimassa? eperuste) (siirtyma? eperuste)))
-      eperuste)))
-
-(defn- find-eperuste-for-koulutuskoodi
-  [sources koulutus-koodi-uri]
-  (when-let [eperusteet (filter #(koulutus? % koulutus-koodi-uri) sources)]
-    (or (first (filter voimassa? eperusteet))
-        (first (filter siirtyma? eperusteet)))))
-
-(defn- get-kuvaus
-  [koulutus-koodi-uri sources]
-  (when-let [eperuste (find-eperuste-for-koulutuskoodi sources koulutus-koodi-uri)]
-    (let [koulutus (get-koulutus eperuste koulutus-koodi-uri)]
-      (merge (select-keys eperuste [:id :kuvaus :tyotehtavatJoissaVoiToimia :suorittaneenOsaaminen])
-             (select-keys koulutus [:nimi :koulutuskoodiUri])))))
+  (get-source index id))
 
 (defonce source [:koulutukset.nimi,
                  :koulutukset.koulutuskoodiUri
@@ -72,44 +30,12 @@
                  :voimassaoloLoppuu
                  :siirtymaPaattyy])
 
-(defn- ->query
-  [koulutuskoodit]
-  (let [terms (if (= 1 (count koulutuskoodit))
-                {:term  {:koulutukset.koulutuskoodiUri (first koulutuskoodit)}}
-                {:terms {:koulutukset.koulutuskoodiUri (vec koulutuskoodit)}})]
-    {:bool {:must terms, :filter {:term {:tila "valmis"}}}}))
-
 (defn- ->id-query
   [eperuste-ids]
   (let [terms (if (= 1 (count eperuste-ids))
                 {:term  {:id (first eperuste-ids)}}
                 {:terms {:id (vec eperuste-ids)}})]
     {:bool {:must terms, :filter {:term {:tila "valmis"}}}}))
-
-
-
-(defn- kuvaukset-result-mapper
-  [koulutus-koodi-urit result]
-  (when-let [sources (seq (map :_source (get-in result [:hits :hits])))]
-    (->> (for [koulutus-koodi-uri koulutus-koodi-urit]
-           (get-kuvaus koulutus-koodi-uri sources))
-         (remove nil?)
-         (vec))))
-
-(defn get-kuvaus-by-koulutuskoodi
-  [koulutuskoodi-uri]
-  (let [koulutuskoodi (koodi-uri-no-version koulutuskoodi-uri)]
-    (eperuste-search #(first (kuvaukset-result-mapper [koulutuskoodi] %))
-                     :_source source
-                     :query (->query [koulutuskoodi]))))
-
-(defn get-kuvaukset-by-koulutuskoodit
-  [koulutuskoodi-uris]
-  (when-let [koulutuskoodit (seq (distinct (map koodi-uri-no-version koulutuskoodi-uris)))]
-    (eperuste-search (partial kuvaukset-result-mapper koulutuskoodit)
-                     :_source source
-                     :size (* 10 (count koulutuskoodit))
-                     :query (->query koulutuskoodit))))
 
 (defn- parse-kuvaukset
   [result]

--- a/src/konfo_backend/search/koulutus/search.clj
+++ b/src/konfo_backend/search/koulutus/search.clj
@@ -22,7 +22,8 @@
          (filter #(= (:id %) eperuste-id))
          (first)
          (select-kuvaus)
-         (assoc hit :kuvaus))))
+         (assoc hit :kuvaus))
+    hit))
 
 (defn- with-kuvaukset
   [result]

--- a/test/konfo_backend/index/eperuste_test.clj
+++ b/test/konfo_backend/index/eperuste_test.clj
@@ -14,7 +14,8 @@
   (str "/konfo-backend/kuvaus/" koulutuskoodi-uri))
 
 (defonce voimassa {:voimassaoloAlkaa (- (now-in-millis) 1000),
-                   :kuvaus {:fi "kuvaus fi" :sv "kuvaus sv"},
+                   :tyotehtavatJoissaVoiToimia  {:fi "työtehtävät fi" :sv "työtehtävät sv"},
+                   :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"},
                    :id 3536456,
                    :koulutukset [{:nimi {:fi "Ammattisukeltajan ammattitutkinto",
                                          :sv "Yrkesexamen för yrkesdykare",
@@ -76,8 +77,8 @@
                                 :en "Further vocational qualification for Commercial Divers"},
                          :koulutuskoodiUri "koulutus_355201",
                          :id 3536456,
-                         :kuvaus {:fi "kuvaus fi"
-                                  :sv "kuvaus sv"}})))))
+                         :tyotehtavatJoissaVoiToimia  {:fi "työtehtävät fi" :sv "työtehtävät sv"},
+                         :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"}})))))
 
   (testing "Get siirtyma-ajalla oleva if there is no voimassa oleva kuvaus"
     (with-redefs [clj-elasticsearch.elastic-connect/search (fn [x y & z] mocked-response-siirtyma)]
@@ -97,8 +98,8 @@
                                 :en "Further vocational qualification for Commercial Divers"},
                          :koulutuskoodiUri "koulutus_355201",
                          :id 3536456,
-                         :kuvaus {:fi "kuvaus fi"
-                                  :sv "kuvaus sv"}
+                         :tyotehtavatJoissaVoiToimia  {:fi "työtehtävät fi" :sv "työtehtävät sv"},
+                         :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"},
                          :osaamisalat [{:nimi {:fi "Osaamisala 1 nimi fi" :sv "Osaamisala 1 nimi sv"}
                                         :osaamisalakoodiUri "osaamisala_1"
                                         :id 123

--- a/test/konfo_backend/index/eperuste_test.clj
+++ b/test/konfo_backend/index/eperuste_test.clj
@@ -10,10 +10,11 @@
   (str "/konfo-backend/eperuste/" id))
 
 (defn kuvaus-url
-  [koulutuskoodi-uri]
-  (str "/konfo-backend/kuvaus/" koulutuskoodi-uri))
+  [eperuste-id]
+  (str "/konfo-backend/kuvaus/" eperuste-id))
 
-(defonce voimassa {:voimassaoloAlkaa (- (now-in-millis) 1000),
+(defonce voimassa {:tila "valmis",
+                   :voimassaoloAlkaa (- (now-in-millis) 1000),
                    :tyotehtavatJoissaVoiToimia  {:fi "työtehtävät fi" :sv "työtehtävät sv"},
                    :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"},
                    :id 3536456,
@@ -22,47 +23,9 @@
                                          :en "Further vocational qualification for Commercial Divers"},
                                   :koulutuskoodiUri "koulutus_355201"}]})
 
-(defonce siirtyma {:voimassaoloAlkaa  (- (now-in-millis) 10000),
-                   :voimassaoloLoppuu (- (now-in-millis) 5000),
-                   :siirtymaPaattyy   (+ (now-in-millis) 100000)
-                   :kuvaus {:fi "kuvaus fi" :sv "kuvaus sv"},
-                   :id 3536457,
-                   :koulutukset [{:nimi {:fi "Ammattisukeltajan ammattitutkinto siirtymä",
-                                         :sv "Yrkesexamen för yrkesdykare siirtymä",
-                                         :en "Further vocational qualification for Commercial Divers siirtymä"},
-                                  :koulutuskoodiUri "koulutus_355201"}]})
-
-(defonce tuleva {:voimassaoloAlkaa (+ (now-in-millis) 100000),
-                 :kuvaus {:fi "kuvaus fi" :sv "kuvaus sv"},
-                 :id 3536458,
-                 :koulutukset [{:nimi {:fi "Ammattisukeltajan ammattitutkinto tuleva",
-                                       :sv "Yrkesexamen för yrkesdykare tuleva",
-                                       :en "Further vocational qualification for Commercial Divers tuleva"},
-                                :koulutuskoodiUri "koulutus_355201"}]})
-
-(defonce vanha {:voimassaoloAlkaa  (- (now-in-millis) 10000),
-                :voimassaoloLoppuu (- (now-in-millis) 5000),
-                :kuvaus {:fi "kuvaus fi" :sv "kuvaus sv"},
-                :id 3536459,
-                :koulutukset [{:nimi {:fi "Ammattisukeltajan ammattitutkinto vanha",
-                                      :sv "Yrkesexamen för yrkesdykare vanha",
-                                      :en "Further vocational qualification for Commercial Divers vanha"},
-                               :koulutuskoodiUri "koulutus_355201"}]})
-
 (defonce mocked-response-voimassa
-  {:hits {:total 2,
-          :hits [{:_source voimassa},
-                 {:_source siirtyma}]}})
-
-(defonce mocked-response-siirtyma
-         {:hits {:total 2,
-                 :hits [{:_source vanha},
-                        {:_source siirtyma}]}})
-
-(defonce mocked-response-nothing
-         {:hits {:total 2,
-                 :hits [{:_source vanha},
-                        {:_source tuleva}]}})
+  {:found true,
+   :_source voimassa})
 
 (defonce mocked-osaamisala-response
   {:hits {:total 2
@@ -71,33 +34,17 @@
 
 (deftest eperuste-test
   (testing "Get eperuste-kuvaus"
-    (with-redefs [clj-elasticsearch.elastic-connect/search (fn [x y & z] mocked-response-voimassa)]
-      (let [response (get-ok (kuvaus-url "koulutus_355201%231"))]
-        (is (= response {:nimi {:fi "Ammattisukeltajan ammattitutkinto", :sv "Yrkesexamen för yrkesdykare",
-                                :en "Further vocational qualification for Commercial Divers"},
-                         :koulutuskoodiUri "koulutus_355201",
-                         :id 3536456,
+    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] mocked-response-voimassa)]
+      (let [response (get-ok (kuvaus-url "3536456"))]
+        (is (= response {:id 3536456,
                          :tyotehtavatJoissaVoiToimia  {:fi "työtehtävät fi" :sv "työtehtävät sv"},
                          :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"}})))))
 
-  (testing "Get siirtyma-ajalla oleva if there is no voimassa oleva kuvaus"
-    (with-redefs [clj-elasticsearch.elastic-connect/search (fn [x y & z] mocked-response-siirtyma)]
-      (let [response (get-ok (kuvaus-url "koulutus_355201%231"))]
-        (is (= (:id response) 3536457)))))
-
-  (testing "Get nothing if there is no voimassa oleva or siirtyma-ajalla oleva kuvaus"
-    (with-redefs [clj-elasticsearch.elastic-connect/search (fn [x y & z] mocked-response-nothing)]
-      (get-not-found (kuvaus-url "koulutus_355201%231"))))
-
   (testing "Get eperuste-kuvaus with osaamisalakuvaukset"
-    (with-redefs [clj-elasticsearch.elastic-connect/search (fn [i y & z] (if (= "eperuste" i)
-                                                                           mocked-response-voimassa
-                                                                           mocked-osaamisala-response))]
+    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] mocked-response-voimassa)
+                  clj-elasticsearch.elastic-connect/search (fn [i y & z] mocked-osaamisala-response)]
       (let [response (get-ok (str (kuvaus-url "koulutus_355201%231") "?osaamisalakuvaukset=true"))]
-        (is (= response {:nimi {:fi "Ammattisukeltajan ammattitutkinto", :sv "Yrkesexamen för yrkesdykare",
-                                :en "Further vocational qualification for Commercial Divers"},
-                         :koulutuskoodiUri "koulutus_355201",
-                         :id 3536456,
+        (is (= response {:id 3536456,
                          :tyotehtavatJoissaVoiToimia  {:fi "työtehtävät fi" :sv "työtehtävät sv"},
                          :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"},
                          :osaamisalat [{:nimi {:fi "Osaamisala 1 nimi fi" :sv "Osaamisala 1 nimi sv"}
@@ -110,11 +57,6 @@
                                         :id 124
                                         :suoritustapa "ops"
                                         :kuvaus {:fi "Osaamisala 2 teksti fi" :sv "Osaamisala 2 teksti sv"}}]})))))
-
-  (testing "Get valmis eperuste"
-    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] {:found true :_source {:id 3536456 :tila "valmis" :voimassaoloAlkaa  (- (now-in-millis) 10000)}})]
-      (let [response (get-ok (eperuste-url 3536456))]
-        (is (= (:id response) 3536456)))))
 
   (testing "Don't get not valmis eperuste"
     (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] {:found true :_source {:id 3536456 :tila "luonnos" :voimassaoloAlkaa  (- (now-in-millis) 10000)}})]

--- a/test/konfo_backend/search/koulutus_search_test.clj
+++ b/test/konfo_backend/search/koulutus_search_test.clj
@@ -26,6 +26,10 @@
   [& query-params]
   (:body (get-bad-request (apply koulutus-search-url query-params))))
 
+(defn mock-get-kuvaukset
+  [x]
+  [{:id 1234 :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"} :tyotehtavatJoissaVoiToimia {:fi "työtehtävät fi" :sv "työtehtävät sv"}}])
+
 (deftest koulutus-search-test
 
   (fixture/add-koulutus-mock "1.2.246.562.13.000001" :koulutustyyppi "amm" :tila "julkaistu" :nimi "Autoalan koulutus" :tarjoajat punkaharjun-yliopisto :metadata koulutus-metatieto)
@@ -34,7 +38,8 @@
 
   (fixture/index-oids-without-related-indices {:koulutukset ["1.2.246.562.13.000001" "1.2.246.562.13.000002"] :oppilaitokset [punkaharjun-yliopisto]} (fn [x & {:as params}] punkaharju-org))
 
-  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto mock-get-koodisto]
+  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto mock-get-koodisto
+                konfo-backend.index.eperuste/get-kuvaukset-by-eperuste-ids mock-get-kuvaukset]
     (testing "Search koulutukset with bad requests:"
       (testing "Invalid lng"
         (is (= "Virheellinen kieli")      (->bad-request-body :sijainti "kunta_618" :lng "foo")))
@@ -101,7 +106,7 @@
           (is (= {:opintojenlaajuusyksikko {:koodiUri   "opintojenlaajuusyksikko_6",
                                             :nimi  {:fi "opintojenlaajuusyksikko_6 nimi fi",
                                                     :sv "opintojenlaajuusyksikko_6 nimi sv"}},
-                  :kuvaus { },
+                  :kuvaus {:fi "osaaminen fi" :sv "osaaminen sv"},
                   :teemakuva "https://testi.fi/koulutus-teemakuva/oid/kuva.jpg",
                   :nimi {:fi "Autoalan koulutus fi",
                          :sv "Autoalan koulutus sv"},


### PR DESCRIPTION
- Poistettu mahdollisuus hakea eperusteita koulutuskoodin perusteella
- Haetaan koulutuksen kuvaukseksi amm koulutukselle eperusteelta tutkinnon suorittaneen osaaminen ja työtehtävät