### PR TITLE
Kto 984

### DIFF
--- a/src/konfo_backend/external/schema/sorakuvaus.clj
+++ b/src/konfo_backend/external/schema/sorakuvaus.clj
@@ -74,13 +74,13 @@
   {:id s/Str
    :koulutustyyppi Koulutustyyppi
    :tila Julkaistu
-   :kielivalinta                 [Kieli]
-   :nimi                         Kielistetty
-   :metadata                     {(s/optional-key :kuvaus) Kielistetty
-                                  (s/optional-key :koulutus) (->Koodi KoulutusKoodi)
-                                  (s/optional-key :koulutusala) (->Koodi Koulutusala1Koodi)}
-   :organisaatio                 Organisaatio
-   :modified                     Datetime})
+   :kielivalinta [Kieli]
+   :nimi Kielistetty
+   :metadata {(s/optional-key :kuvaus) Kielistetty
+              (s/optional-key :koulutus) [(->Koodi KoulutusKoodi)]
+              (s/optional-key :koulutusala) (->Koodi Koulutusala1Koodi)}
+   :organisaatio Organisaatio
+   :modified Datetime})
 
 (def schemas
   sorakuvaus-schema)

--- a/src/konfo_backend/external/schema/sorakuvaus.clj
+++ b/src/konfo_backend/external/schema/sorakuvaus.clj
@@ -78,7 +78,9 @@
    :nimi Kielistetty
    :metadata {(s/optional-key :kuvaus) Kielistetty
               (s/optional-key :koulutus) [(->Koodi KoulutusKoodi)]
-              (s/optional-key :koulutusala) (->Koodi Koulutusala1Koodi)}
+              (s/optional-key :koulutusala) (s/if #(re-matches Koulutusala1Koodi (:koodiUri %))
+                                              (->Koodi Koulutusala1Koodi)
+                                              (->Koodi Koulutusala2Koodi))}
    :organisaatio Organisaatio
    :modified Datetime})
 

--- a/src/konfo_backend/external/schema/sorakuvaus.clj
+++ b/src/konfo_backend/external/schema/sorakuvaus.clj
@@ -49,9 +49,17 @@
    |              description: SORA-kuvauksen kuvausteksti eri kielillä. Kielet on määritetty kuvauksen kielivalinnassa.
    |              $ref: '#/components/schemas/Kuvaus'
    |            koulutus:
+   |              type: array
+   |              description: Koulutusten koodi urit ja nimet
+   |              items:
+   |                type: object
+   |                $ref: '#/components/schemas/KoulutusKoodi'
+   |            koulutusala:
    |              type: object
-   |              description: Koulutuksen koodi uri ja nimi
-   |              $ref: '#/components/schemas/KoulutusKoodi'
+   |              description: Koulutusalan koodi URI ja nimi.
+   |              oneOf:
+   |                - $ref: '#/components/schemas/Koulutusala1'
+   |                - $ref: '#/components/schemas/Koulutusala2'
    |        organisaatio:
    |          type: object
    |          description: Valintaperustekuvauksen luoneen organisaation oid
@@ -69,7 +77,8 @@
    :kielivalinta                 [Kieli]
    :nimi                         Kielistetty
    :metadata                     {(s/optional-key :kuvaus) Kielistetty
-                                  (s/optional-key :koulutus) (->Koodi KoulutusKoodi)}
+                                  (s/optional-key :koulutus) (->Koodi KoulutusKoodi)
+                                  (s/optional-key :koulutusala) (->Koodi Koulutusala1Koodi)}
    :organisaatio                 Organisaatio
    :modified                     Datetime})
 

--- a/src/konfo_backend/external/schema/sorakuvaus.clj
+++ b/src/konfo_backend/external/schema/sorakuvaus.clj
@@ -39,8 +39,7 @@
    |        nimi:
    |          type: object
    |          description: SORA-kuvauksen Opintopolussa näytettävä nimi eri kielillä. Kielet on määritetty SORA-kuvauksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        metadata:
    |          type: object
    |          description: SORA-kuvauksen kuvailutiedot eri kielillä
@@ -48,13 +47,15 @@
    |            kuvaus:
    |              type: object
    |              description: SORA-kuvauksen kuvausteksti eri kielillä. Kielet on määritetty kuvauksen kielivalinnassa.
-   |              allOf:
-   |                - $ref: '#/components/schemas/Kuvaus'
+   |              $ref: '#/components/schemas/Kuvaus'
+   |            koulutus:
+   |              type: object
+   |              description: Koulutuksen koodi uri ja nimi
+   |              $ref: '#/components/schemas/KoulutusKoodi'
    |        organisaatio:
    |          type: object
    |          description: Valintaperustekuvauksen luoneen organisaation oid
-   |          allOf:
-   |            - $ref: '#/components/schemas/Organisaatio'
+   |          $ref: '#/components/schemas/Organisaatio'
    |        modified:
    |          type: string
    |          format: date-time
@@ -67,7 +68,8 @@
    :tila Julkaistu
    :kielivalinta                 [Kieli]
    :nimi                         Kielistetty
-   :metadata                     {(s/->OptionalKey :kuvaus) Kielistetty}
+   :metadata                     {(s/optional-key :kuvaus) Kielistetty
+                                  (s/optional-key :koulutus) (->Koodi KoulutusKoodi)}
    :organisaatio                 Organisaatio
    :modified                     Datetime})
 

--- a/src/konfo_backend/search/query.clj
+++ b/src/konfo_backend/search/query.clj
@@ -57,7 +57,7 @@
   (let [size (->size size)
         from (->from page size)]
     {:bool {:must [{:term {:oid oid}}
-                   {:nested {:inner_hits {:_source ["hits.koulutusOid", "hits.toteutusOid", "hits.opetuskielet", "hits.oppilaitosOid", "hits.kuva", "hits.nimi", "hits.metadata"]
+                   {:nested {:inner_hits {:_source ["hits.koulutusOid", "hits.toteutusOid", "hits.toteutusNimi", "hits.opetuskielet", "hits.oppilaitosOid", "hits.kuva", "hits.nimi", "hits.metadata"]
                                           :from from
                                           :size size
                                           :sort {(str "hits.nimi." lng ".keyword") {:order order :unmapped_type "string"}}}

--- a/src/konfo_backend/search/response.clj
+++ b/src/konfo_backend/search/response.clj
@@ -87,7 +87,7 @@
     (vec (for [hit hits
                :let [toteutusOid (:toteutusOid hit)]]
            (-> hit
-               (select-keys [:koulutusOid :oppilaitosOid :toteutusOid :nimi :koulutustyyppi :kuva])
+               (select-keys [:koulutusOid :oppilaitosOid :toteutusNimi :opetuskielet :toteutusOid :nimi :koulutustyyppi :kuva])
                (merge (:metadata hit))
                (assoc :kuvaus (if (not (nil? toteutusOid))
                                 (or ((keyword toteutusOid) kuvaukset) {})

--- a/test/konfo_backend/search/koulutus_jarjestajat_search_test.clj
+++ b/test/konfo_backend/search/koulutus_jarjestajat_search_test.clj
@@ -124,6 +124,8 @@
                                        :nimi {:fi "tutkintonimikkeet_02 nimi fi",
                                               :sv "tutkintonimikkeet_02 nimi sv"}}],
                   :oppilaitosTila nil,
+                  :opetuskielet ["oppilaitoksenopetuskieli_02"]
+                  :toteutusNimi {:fi "Ponikoulu fi", :sv "Ponikoulu sv"},
                   :koulutustyyppi "yo"} (first (:hits r))))))
 
       (testing "tulevat"
@@ -134,6 +136,7 @@
                          :sv "Helsingin yliopisto sv"},
                   :oppilaitosTila nil,
                   :koulutustyyppi "yo",
+                  :opetuskielet [],
                   :kunnat [{:koodiUri "kunta_091",
                             :nimi {:fi "kunta_091 nimi fi",
                                    :sv "kunta_091 nimi sv"}}],

--- a/test/konfo_backend/search/oppilaitos_tarjonta_search_test.clj
+++ b/test/konfo_backend/search/oppilaitos_tarjonta_search_test.clj
@@ -130,6 +130,7 @@
                             :nimi {:fi "kunta_091 nimi fi",
                                    :sv "kunta_091 nimi sv"}}],
                   :tutkintonimikkeet nil,
+                  :opetuskielet ["oppilaitoksenopetuskieli_02"],
                   :koulutustyyppi "amm",
                   :kuva "https://example.com/kuva.jpg"} (first (:hits r))))))
 
@@ -157,6 +158,7 @@
                   :kunnat [{:koodiUri "kunta_091",
                             :nimi {:fi "kunta_091 nimi fi",
                                    :sv "kunta_091 nimi sv"}}],
+                  :opetuskielet [],
                   :tutkintonimikkeet [{:koodiUri "tutkintonimikkeet_01",
                                        :nimi {:fi "tutkintonimikkeet_01 nimi fi",
                                               :sv "tutkintonimikkeet_01 nimi sv"}},


### PR DESCRIPTION
Lisätty search/koulutus/:oid/jarjestajat rajapinnan palautusarvoihin toteutusNimi ja opetuskielet. Korjattu sorakuvauksen metadatan skeema, koska KTO-875 tiketillä lisättiin metadataan koulutusKoodiUri ja koulutusalaKoodiUri. Nämä kentät rikastetaan indeksoijassa, joten konfo-backendin skeemaan laitettu rikastuksen muotoisesti.