### PR TITLE
Kto 1050 bugfix

### DIFF
--- a/src/konfo_backend/search/response.clj
+++ b/src/konfo_backend/search/response.clj
@@ -99,7 +99,7 @@
   ([response filter-generator]
    (if-let [inner-hits (some-> response :hits :hits (first) :inner_hits :hits :hits)]
      {:total (:total inner-hits) :hits (inner-hits-with-kuvaukset inner-hits) :filters (filter-generator response)}
-     {:total 0 :hits [] :filters {}})))
+     {:total 0 :hits [] :filters (filter-generator response)})))
 
 (defn parse-inner-hits-for-jarjestajat
   [response]

--- a/src/konfo_backend/search/response.clj
+++ b/src/konfo_backend/search/response.clj
@@ -97,9 +97,11 @@
   ([response]
    (parse-inner-hits response filters))
   ([response filter-generator]
-   (if-let [inner-hits (some-> response :hits :hits (first) :inner_hits :hits :hits)]
-     {:total (:total inner-hits) :hits (inner-hits-with-kuvaukset inner-hits) :filters (filter-generator response)}
-     {:total 0 :hits [] :filters (filter-generator response)})))
+   (let [inner-hits (some-> response :hits :hits (first) :inner_hits :hits :hits)
+         total-inner-hits (:total inner-hits)]
+     {:total (or total-inner-hits 0)
+      :hits (inner-hits-with-kuvaukset inner-hits)
+      :filters (filter-generator response)})))
 
 (defn parse-inner-hits-for-jarjestajat
   [response]


### PR DESCRIPTION
search/koulutus/:oid/jarjestajat api palautti tyhjän filters-olion jos hakutuloksia ei löytynyt. Korjattu palauttamaan filtterit hakutuloksesta riippumatta