### PR TITLE
External skeeman korjauksia

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,18 +48,18 @@
              :updater {:jvm-opts ["-Dmode=updater" "-Dport=3006"]}
              :test {:dependencies [[ring/ring-mock "0.3.2"]
                                    [kouta-indeksoija-service "0.4.9-SNAPSHOT"]
-                                   [fi.oph.kouta/kouta-backend "1.1.2-SNAPSHOT"]
-                                   [fi.oph.kouta/kouta-backend "1.1.2-SNAPSHOT" :classifier "tests"]
-                                   [fi.oph.kouta/kouta-common "1.1.2-SNAPSHOT" :classifier "tests"]
+                                   [fi.oph.kouta/kouta-backend "1.1.3-SNAPSHOT"]
+                                   [fi.oph.kouta/kouta-backend "1.1.3-SNAPSHOT" :classifier "tests"]
+                                   [fi.oph.kouta/kouta-common "1.1.3-SNAPSHOT" :classifier "tests"]
                                    [org.mockito/mockito-core "2.28.2"]
                                    [oph/clj-test-utils "0.2.8-SNAPSHOT"]]
                     :injections [(require '[clj-test-utils.elasticsearch-docker-utils :as utils])
                                  (utils/global-docker-elastic-fixture)]}
              :ci-test {:dependencies [[ring/ring-mock "0.3.2"]
                                       [kouta-indeksoija-service "0.4.9-SNAPSHOT"]
-                                      [fi.oph.kouta/kouta-backend "1.1.2-SNAPSHOT"]
-                                      [fi.oph.kouta/kouta-backend "1.1.2-SNAPSHOT" :classifier "tests"]
-                                      [fi.oph.kouta/kouta-common "1.1.2-SNAPSHOT" :classifier "tests"]
+                                      [fi.oph.kouta/kouta-backend "1.1.3-SNAPSHOT"]
+                                      [fi.oph.kouta/kouta-backend "1.1.3-SNAPSHOT" :classifier "tests"]
+                                      [fi.oph.kouta/kouta-common "1.1.3-SNAPSHOT" :classifier "tests"]
                                       [org.mockito/mockito-core "2.28.2"]
                                       [oph/clj-test-utils "0.2.8-SNAPSHOT"]]
                        :injections [(require '[clj-test-utils.elasticsearch-docker-utils :as utils])

--- a/src/konfo_backend/external/api.clj
+++ b/src/konfo_backend/external/api.clj
@@ -12,6 +12,7 @@
     [konfo-backend.external.schema.haku :as haku]
     [konfo-backend.external.schema.valintakoe :as valintakoe]
     [konfo-backend.external.schema.valintaperustekuvaus :as valintaperuste]
+    [konfo-backend.external.schema.valintaperustekuvaus-metadata :as valintaperuste-metadata]
     [konfo-backend.external.schema.sorakuvaus :as sorakuvaus]
     [konfo-backend.external.schema.response :as response]
     [konfo-backend.external.schema.liite :as liite]
@@ -292,6 +293,7 @@
        liite/schemas "\n"
        haku/schemas "\n"
        valintaperuste/schemas "\n"
+       valintaperuste-metadata/schemas "\n"
        sorakuvaus/schemas "\n"
        search/schemas "\n"
        response/schemas))

--- a/src/konfo_backend/external/schema/common.clj
+++ b/src/konfo_backend/external/schema/common.clj
@@ -119,13 +119,11 @@
    |        paikkakunta:
    |          type: object
    |          description: Organisaation paikkakunta.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kunta'
+   |          $ref: '#/components/schemas/Kunta'
    |        nimi:
    |          type: object
    |          description: Organisaation nimi eri kielillä.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        oid:
    |          type: String
    |          example: 1.2.246.562.10.00000000007
@@ -142,13 +140,11 @@
    |      properties:
    |        otsikko:
    |          type: object
-   |          allOf:
-   |            - $ref: '#/components/schemas/KoulutusLisatietoKoodi'
+   |          $ref: '#/components/schemas/KoulutusLisatietoKoodi'
    |        teksti:
    |          type: object
    |          description: Lisätiedon teksti eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def KoulutusLisatieto
   {:otsikko (->Koodi KoulutusLisatietoKoodi)
@@ -161,28 +157,23 @@
    |        nimi:
    |          type: object
    |          description: Yhteyshenkilön nimi eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        titteli:
    |          type: object
    |          description: Yhteyshenkilön titteli eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'
+   |          $ref: '#/components/schemas/Teksti'
    |        sahkoposti:
    |          type: object
    |          description: Yhteyshenkilön sähköpostiosoite eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'
+   |          $ref: '#/components/schemas/Teksti'
    |        puhelinnumero:
    |          type: object
    |          description: Yhteyshenkilön puhelinnumero eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'
+   |          $ref: '#/components/schemas/Teksti'
    |        wwwSivu:
    |          type: object
    |          description: Yhteyshenkilön www-sivu eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Linkki'")
+   |          $ref: '#/components/schemas/Linkki'")
 
 (def Yhteyshenkilo
   {:nimi          Kielistetty
@@ -259,13 +250,11 @@
    |        osoite:
    |          type: object
    |          description: Osoite eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'
+   |          $ref: '#/components/schemas/Teksti'
    |        postinumero:
    |          type: object
    |          description: Postinumero ja -toimipaikka
-   |          allOf:
-   |            - $ref: '#/components/schemas/Postinumero'")
+   |          $ref: '#/components/schemas/Postinumero'")
 
 (def Osoite
   {:osoite Kielistetty

--- a/src/konfo_backend/external/schema/common.clj
+++ b/src/konfo_backend/external/schema/common.clj
@@ -271,6 +271,7 @@
        kuvaus-schema "\n"
        nimi-schema "\n"
        teksti-schema "\n"
+       linkki-schema "\n"
        organisaatio-schema "\n"
        koulutuslisatieto-schema "\n"
        yhteyshenkilo-schema "\n"

--- a/src/konfo_backend/external/schema/common.clj
+++ b/src/konfo_backend/external/schema/common.clj
@@ -238,14 +238,19 @@
    |        koulutuksenAlkamisvuosi:
    |          type: string
    |          description: Haun koulutusten alkamisvuosi. Hakukohteella voi olla eri alkamisvuosi kuin haulla.
-   |          example: 2020")
+   |          example: 2020
+   |        henkilokohtaisenSuunnitelmanLisatiedot:
+   |          type: object
+   |          description: Lisätietoa koulutuksen alkamisesta henkilökohtaisen suunnitelman mukaan.
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def KoulutuksenAlkamiskausi
   {(s/->OptionalKey :alkamiskausityyppi) (s/maybe Alkamiskausityyppi)
    (s/->OptionalKey :koulutuksenAlkamispaivamaara) (s/maybe Datetime)
    (s/->OptionalKey :koulutuksenPaattymispaivamaara) (s/maybe Datetime)
    (s/->OptionalKey :koulutuksenAlkamiskausi) (s/maybe (->Koodi AlkamiskausiKoodi))
-   (s/->OptionalKey :koulutuksenAlkamisvuosi) (s/maybe s/Str)})
+   (s/->OptionalKey :koulutuksenAlkamisvuosi) (s/maybe s/Str)
+   (s/->OptionalKey :henkilokohtaisenSuunnitelmanLisatiedot) (s/maybe Kielistetty)})
 
 (def osoite-schema
   "|    Osoite:

--- a/src/konfo_backend/external/schema/haku.clj
+++ b/src/konfo_backend/external/schema/haku.clj
@@ -22,8 +22,7 @@
    |        nimi:
    |          type: object
    |          description: Haun nimi eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        hakutapa:
    |          type: object
    |          description: Haun hakutapa
@@ -49,13 +48,11 @@
    |        hakulomakeKuvaus:
    |          type: object
    |          description: Hakulomakkeen kuvausteksti eri kielillä. Kielet on määritetty haun kielivalinnassa. Hakukohteella voi olla eri hakulomake kuin haulla.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        hakulomakeLinkki:
    |          type: object
    |          description: Hakulomakkeen linkki eri kielillä. Kielet on määritetty haun kielivalinnassa. Hakukohteella voi olla eri hakulomake kuin haulla.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Linkki'
+   |          $ref: '#/components/schemas/Linkki'
    |        hakuajat:
    |          type: array
    |          description: Haun hakuajat. Hakukohteella voi olla omat hakuajat.
@@ -89,8 +86,7 @@
    |        organisaatio:
    |          type: object
    |          description: Haun luonut organisaatio
-   |          allOf:
-   |           - $ref: '#/components/schemas/Organisaatio'
+   |          $ref: '#/components/schemas/Organisaatio'
    |        modified:
    |           type: string
    |           format: date-time

--- a/src/konfo_backend/external/schema/hakukohde.clj
+++ b/src/konfo_backend/external/schema/hakukohde.clj
@@ -114,6 +114,10 @@
    |          description: Hakukohteen hakuajat, jos ei käytetä haun hakuaikoja
    |          items:
    |            $ref: '#/components/schemas/Ajanjakso'
+   |        valintaperustekuvaus:
+   |          type: object
+   |          description: Hakukohteeseen liittyvä valintaperustekuvaus
+   |          $ref: '#/components/schemas/Valintaperustekuvaus'
    |        liitteetOnkoSamaToimitusaika:
    |          type: boolean
    |          description: Onko kaikilla hakukohteen liitteillä sama toimitusaika?
@@ -199,6 +203,7 @@
    :liitteet                                       [Liite]
    :valintakokeet                                  [Valintakoe]
    :kielivalinta                                   [Kieli]
+   (s/->OptionalKey :valintaperustekuvaus)         Valintaperustekuvaus
    (s/->OptionalKey :metadata)                     HakukohdeMetadata
    :organisaatio                                   Organisaatio
    :modified                                       Datetime

--- a/src/konfo_backend/external/schema/hakukohde.clj
+++ b/src/konfo_backend/external/schema/hakukohde.clj
@@ -16,8 +16,7 @@
    |        valintakokeidenYleiskuvaus:
    |          type: object
    |          description: Valintakokeiden yleiskuvaus eri kielillä. Kielet on määritetty hakukohteen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'")
+   |          $ref: '#/components/schemas/Kuvaus'")
 
 (def HakukohdeMetadata
   {:valintakokeidenYleiskuvaus Kielistetty})
@@ -47,8 +46,7 @@
    |        nimi:
    |          type: object
    |          description: Hakukohteen nimi eri kielillä. Kielet on määritetty hakukohteen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        alkamiskausi:
    |          type: object
    |          description: Hakukohteen koulutuksen alkamiskausi, jos ei käytetän haun alkamiskautta
@@ -63,8 +61,7 @@
    |        jarjestyspaikka:
    |          type: object
    |          description: Se organisaatio, jossa järjestetään koulutus, johon hakukohteessa voi hakea
-   |          allOf:
-   |            - $ref: '#/components/schemas/Organisaatio'
+   |          $ref: '#/components/schemas/Organisaatio'
    |        hakulomaketyyppi:
    |          type: string
    |          description: Hakulomakkeen tyyppi. Kertoo, käytetäänkö Atarun (hakemuspalvelun) hakulomaketta, muuta hakulomaketta
@@ -82,8 +79,7 @@
    |        hakulomakeLinkki:
    |          type: object
    |          description: Hakulomakkeen linkki eri kielillä. Kielet on määritetty haun kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Linkki'
+   |          $ref: '#/components/schemas/Linkki'
    |        kaytetaanHaunHakulomaketta:
    |          type: boolean
    |          description: Käytetäänkö haun hakulomaketta vai onko hakukohteelle määritelty oma hakulomake?
@@ -103,13 +99,11 @@
    |        muuPohjakoulutusvaatimus:
    |          type: object
    |          description: Hakukohteen muiden pohjakoulutusvaatimusten kuvaus eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        pohjakoulutusvaatimusTarkenne:
    |          type: object
    |          description: Pohjakoulutusvaatimusten tarkempi kuvaus eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        toinenAsteOnkoKaksoistutkinto:
    |          type: boolean
    |          description: Onko hakukohteen toisen asteen koulutuksessa mahdollista suorittaa kaksoistutkinto?
@@ -124,8 +118,7 @@
    |        valintaperustekuvaus:
    |          type: object
    |          description: Hakukohteeseen liittyvä valintaperustekuvaus
-   |          allOf:
-   |            - $ref: '#/components/schemas/Valintaperustekuvaus'
+   |          $ref: '#/components/schemas/Valintaperustekuvaus'
    |        liitteetOnkoSamaToimitusaika:
    |          type: boolean
    |          description: Onko kaikilla hakukohteen liitteillä sama toimitusaika?
@@ -148,8 +141,7 @@
    |        liitteidenToimitusosoite:
    |          type: object
    |          description: Jos liitteillä on sama toimitusosoite, se ilmoitetaan tässä
-   |          allOf:
-   |            - $ref: '#/components/schemas/LiitteenToimitusosoite'
+   |          $ref: '#/components/schemas/LiitteenToimitusosoite'
    |        liitteet:
    |          type: array
    |          description: Hakukohteen liitteet
@@ -171,8 +163,7 @@
    |        organisaatio:
    |          type: object
    |          description: Hakukohteen luonut organisaatio
-   |          allOf:
-   |           - $ref: '#/components/schemas/Organisaatio'
+   |          $ref: '#/components/schemas/Organisaatio'
    |        modified:
    |          type: string
    |          format: date-time

--- a/src/konfo_backend/external/schema/hakukohde.clj
+++ b/src/konfo_backend/external/schema/hakukohde.clj
@@ -74,8 +74,7 @@
    |        hakulomakeKuvaus:
    |          type: object
    |          description: Hakulomakkeen kuvausteksti eri kielillä. Kielet on määritetty haun kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        hakulomakeLinkki:
    |          type: object
    |          description: Hakulomakkeen linkki eri kielillä. Kielet on määritetty haun kielivalinnassa.

--- a/src/konfo_backend/external/schema/hakukohde.clj
+++ b/src/konfo_backend/external/schema/hakukohde.clj
@@ -115,10 +115,6 @@
    |          description: Hakukohteen hakuajat, jos ei käytetä haun hakuaikoja
    |          items:
    |            $ref: '#/components/schemas/Ajanjakso'
-   |        valintaperustekuvaus:
-   |          type: object
-   |          description: Hakukohteeseen liittyvä valintaperustekuvaus
-   |          $ref: '#/components/schemas/Valintaperustekuvaus'
    |        liitteetOnkoSamaToimitusaika:
    |          type: boolean
    |          description: Onko kaikilla hakukohteen liitteillä sama toimitusaika?

--- a/src/konfo_backend/external/schema/koodi.clj
+++ b/src/konfo_backend/external/schema/koodi.clj
@@ -12,8 +12,7 @@
    |          type: object
    |          description: Kunnan nimi eri kielillä.
    |          example: {\"fi\": \"Helsinki\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def KuntaKoodi    #"^kunta_\d+")
 
@@ -29,8 +28,7 @@
    |          type: object
    |          description: Maakunnan nimi eri kielillä.
    |          example: {\"fi\": \"Uusimaa\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def MaakuntaKoodi    #"^maakunta_\d+")
 
@@ -46,8 +44,7 @@
    |          type: object
    |          description: Koulutuksen nimi eri kielillä.
    |          example: {\"fi\": \"IB-tutkinto\", \"sv\": \"IB-examen\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def KoulutusKoodi #"^koulutus_\d{6}(#\d{1,2})?$")
 
@@ -63,8 +60,7 @@
    |          type: object
    |          description: Koulutusalan nimi eri kielillä.
    |          example: {\"fi\": \"Koulutusala suomeksi\", \"sv\": \"Koulutusala på svenska\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def Koulutusala1Koodi #"^kansallinenkoulutusluokitus2016koulutusalataso1_\d+(#\d{1,2})?$")
 
@@ -80,8 +76,7 @@
    |          type: object
    |          description: Koulutusalan nimi eri kielillä.
    |          example: {\"fi\": \"Koulutusala suomeksi\", \"sv\": \"Koulutusala på svenska\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def Koulutusala2Koodi #"^kansallinenkoulutusluokitus2016koulutusalataso2_\d+(#\d{1,2})?$")
 

--- a/src/konfo_backend/external/schema/koodi.clj
+++ b/src/konfo_backend/external/schema/koodi.clj
@@ -97,8 +97,7 @@
    |          type: object
    |          description: Koulutuksen lisatiedon otsikko eri kielillä.
    |          example: {\"fi\": \"Otsikko suomeksi\", \"sv\": \"Otsikko på svenska\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def KoulutusLisatietoKoodi #"koulutuksenlisatiedot_\d+(#\d{1,2})?$")
 

--- a/src/konfo_backend/external/schema/koodi.clj
+++ b/src/konfo_backend/external/schema/koodi.clj
@@ -113,8 +113,7 @@
    |          type: object
    |          description: Tutkintonimikkeem nimi eri kielillä.
    |          example: {\"fi\": \"Tutkintonimike suomeksi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def TutkintonimikeKoodi #"tutkintonimikkeet_\d+(#\d{1,2})?$")
 
@@ -130,8 +129,7 @@
    |          type: object
    |          description: Tutkintonimikkeem nimi eri kielillä.
    |          example: {\"fi\": \"Tutkintonimike suomeksi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'")
+   |          $ref: '#/components/schemas/Nimi'")
 
 (def TutkintonimikeKkKoodi #"tutkintonimikekk_\d+(#\d{1,2})?$")
 
@@ -147,8 +145,7 @@
    |          type: object
    |          description: Tutkinnon laajuuden eri kielillä.
    |          example: {\"fi\": \"Tutkinnon laajuus suomeksi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def OpintojenLaajuusKoodi #"opintojenlaajuus_\d+(#\d{1,2})?$")
 
@@ -164,8 +161,7 @@
    |          type: object
    |          description: Tutkinnon laajuuden eri kielillä.
    |          example: {\"fi\": \"Tutkinnon laajuus suomeksi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def OpintojenLaajuusyksikkoKoodi #"opintojenlaajuusyksikko_\d+(#\d{1,2})?$")
 
@@ -181,8 +177,7 @@
    |          type: object
    |          description: Opetuskieli eri kielillä.
    |          example: {\"fi\": \"suomi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def OpetuskieliKoodi #"oppilaitoksenopetuskieli_\d+(#\d{1,2})?$")
 
@@ -198,8 +193,7 @@
    |          type: object
    |          description: Kieli eri kielillä.
    |          example: {\"fi\": \"englanti\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def KielitaitovaatimusKieliKoodi #"kieli_\w+(#\d{1,2})?$")
 
@@ -215,8 +209,7 @@
    |          type: object
    |          description: Kielitaidon osoittaminen eri kielillä.
    |          example: {\"fi\": \"englanti\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def KielitaidonOsoitteminenKoodi #"kielitaidonosoittaminen_\d+(#\d{1,2})?$")
 
@@ -232,8 +225,7 @@
    |          type: object
    |          description: Kielitaitovaatimuksen tyyppi eri kielillä.
    |          example: {\"fi\": \"kielitaitovaatimustyyppi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def KielitaitovaatimusTyyppiKoodi #"kielitaitovaatimustyypit_\d+(#\d{1,2})?$")
 
@@ -249,8 +241,7 @@
    |          type: object
    |          description: Kielitaitovaatimuksen kuvaus eri kielillä.
    |          example: {\"fi\": \"kielitaitovaatimustyypin kuvausteksti\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def KielitaitovaatimusTyypinKuvausKoodi #"kielitaitovaatimustyypitkuvaus_\d+(#\d{1,2})?$")
 
@@ -266,8 +257,7 @@
    |          type: object
    |          description: Opetusaika eri kielillä.
    |          example: {\"fi\": \"suomi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def OpetusaikaKoodi #"opetusaikakk_\d+(#\d{1,2})?$")
 
@@ -283,8 +273,7 @@
    |          type: object
    |          description: Opetustapa eri kielillä.
    |          example: {\"fi\": \"suomi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def OpetustapaKoodi #"opetuspaikkakk_\d+(#\d{1,2})?$")
 
@@ -300,8 +289,7 @@
    |          type: object
    |          description: Alkamiskausi eri kielillä
    |          example: {\"fi\": \"syksy\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def AlkamiskausiKoodi #"kausi_\w+(#\d{1,2})?$")
 
@@ -317,8 +305,7 @@
    |          type: object
    |          description: Pohjakoulutusvaatimus eri kielillä
    |          example: {\"fi\": \"syksy\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def PohjakoulutusvaatimusKoodi #"pohjakoulutusvaatimustoinenaste_\w+(#\d{1,2})?$")
 
@@ -334,8 +321,7 @@
    |          type: object
    |          description: Postitoimipaikan nimi eri kielillä
    |          example: {\"fi\": \"Kerava\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def PostinumeroKoodi #"posti_\d+(#\d{1,2})?$")
 
@@ -351,8 +337,7 @@
    |          type: object
    |          description: Liitteen tyyppi eri kielillä
    |          example: {\"fi\": \"Todistus\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def LiitteenTyyppiKoodi #"liitetyypitamm_\d+(#\d{1,2})?$")
 
@@ -368,8 +353,7 @@
    |          type: object
    |          description: Valintakokeen tyyppi eri kielillä
    |          example: {\"fi\": \"Kuulustelu\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def ValintakokeenTyyppiKoodi #"valintakokeentyyppi_\d+(#\d{1,2})?$")
 
@@ -385,8 +369,7 @@
    |          type: object
    |          description: Hakutavan nimi eri kielillä
    |          example: {\"fi\": \"Yhteishaku\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def HakutapaKoodi #"hakutapa_\d+(#\d{1,2})?$")
 
@@ -402,8 +385,7 @@
    |          type: object
    |          description: Haun kohdejoukon nimi eri kielillä
    |          example: {\"fi\": \"Kohdejoukko\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def HaunKohdejoukkoKoodi #"haunkohdejoukko_\d+(#\d{1,2})?$")
 
@@ -419,8 +401,7 @@
    |          type: object
    |          description: Haun kohdejoukon tarkenne eri kielillä
    |          example: {\"fi\": \"Kohdejoukon tarkenne\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def HaunKohdejoukonTarkenneKoodi #"haunkohdejoukontarkenne_\d+(#\d{1,2})?$")
 
@@ -436,8 +417,7 @@
    |          type: object
    |          description: Valintatapa eri kielillä
    |          example: {\"fi\": \"Valintatapa suomeksi\"}
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def ValintatapaKoodi #"valintatapajono_\w+(#\d{1,2})?$")
 
@@ -452,8 +432,7 @@
    |        nimi:
    |          type: object
    |          description: Osaamistausta.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def OsaamistaustaKoodi #"osaamistausta_\d+(#\d{1,2})?$")
 

--- a/src/konfo_backend/external/schema/koulutus.clj
+++ b/src/konfo_backend/external/schema/koulutus.clj
@@ -30,8 +30,7 @@
      |        koulutus:
      |          type: object
      |          description: Koulutuksen koodi uri ja nimi
-     |          allOf:
-     |            - $ref: '#/components/schemas/KoulutusKoodi'
+     |          $ref: '#/components/schemas/KoulutusKoodi'
      |        tila:
      |          type: string
      |          example: \"julkaistu\"
@@ -55,8 +54,7 @@
      |        nimi:
      |          type: object
      |          description: Koulutuksen näytettävä nimi eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-     |          allOf:
-     |            - $ref: '#/components/schemas/Nimi'
+     |          $ref: '#/components/schemas/Nimi'
      |        metadata:
      |          type: object
      |          oneOf:
@@ -96,8 +94,7 @@
      |        organisaatio:
      |          type: object
      |          description: Koulutuksen luonut organisaatio
-     |          allOf:
-     |           - $ref: '#/components/schemas/Organisaatio'
+     |          $ref: '#/components/schemas/Organisaatio'
      |        teemakuva:
      |          type: string
      |          description: Koulutuksen teemakuvan URL.

--- a/src/konfo_backend/external/schema/koulutus_metadata.clj
+++ b/src/konfo_backend/external/schema/koulutus_metadata.clj
@@ -18,8 +18,7 @@
     |        kuvaus:
     |          type: object
     |          description: Koulutuksen kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-    |          allOf:
-    |            - $ref: '#/components/schemas/Kuvaus'
+    |          $ref: '#/components/schemas/Kuvaus'
     |        lisatiedot:
     |          type: array
     |          description: Koulutukseen liittyviä lisätietoja, jotka näkyvät oppijalle
@@ -51,8 +50,7 @@
     |        kuvauksenNimi:
     |          type: object
     |          description: Koulutuksen kuvaukseni nimi eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-    |          allOf:
-    |            - $ref: '#/components/schemas/Nimi'
+    |          $ref: '#/components/schemas/Nimi'
     |        tutkintonimike:
     |          type: array
     |          items:
@@ -68,8 +66,7 @@
     |              type: object
     |              description: Tutkinnon laajuuden eri kielillä.
     |              example: {\"fi\": \"Tutkinnon laajuus suomeksi\"}
-    |              allOf:
-    |                - $ref: '#/components/schemas/Teksti'
+    |              $ref: '#/components/schemas/Teksti'
     |    YliopistoKoulutusMetadata:
     |      allOf:
     |        - $ref: '#/components/schemas/KorkeakouluMetadata'

--- a/src/konfo_backend/external/schema/liite.clj
+++ b/src/konfo_backend/external/schema/liite.clj
@@ -13,13 +13,11 @@
    |        osoite:
    |          type: object
    |          description: Liitteen toimitusosoite
-   |          allOf:
-   |            - $ref: '#/components/schemas/Osoite'
+   |          $ref: '#/components/schemas/Osoite'
    |        sahkoposti:
    |          type: object
    |          description: Sähköpostiosoite, johon liite voidaan toimittaa
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def LiitteenToimitusosoite
   {:sahkoposti s/Str
@@ -40,13 +38,11 @@
       |        nimi:
       |          type: object
       |          description: Liitteen Opintopolussa näytettävä nimi eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-      |          allOf:
-      |            - $ref: '#/components/schemas/Nimi'
+      |          $ref: '#/components/schemas/Nimi'
       |        kuvaus:
       |          type: object
       |          description: Liitteen Opintopolussa näytettävä kuvaus eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-      |          allOf:
-      |            - $ref: '#/components/schemas/Kuvaus'
+      |          $ref: '#/components/schemas/Kuvaus'
       |        toimitusaika:
       |          type: string
       |          description: Liitteen toimitusaika, jos ei ole sama kuin kaikilla hakukohteen liitteillä
@@ -63,8 +59,7 @@
       |        toimitusosoite:
       |          type: object
       |          description: Liitteen toimitusosoite, jos ei ole sama kuin kaikilla hakukohteen liitteillä
-      |          allOf:
-      |            - $ref: '#/components/schemas/LiitteenToimitusosoite'")
+      |          $ref: '#/components/schemas/LiitteenToimitusosoite'")
 
 (def Liite
   {:id             s/Str                                    ;s/Uuid

--- a/src/konfo_backend/external/schema/response.clj
+++ b/src/konfo_backend/external/schema/response.clj
@@ -16,8 +16,7 @@
 (def koulutus-response-schema
   "|    KoulutusResponse:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/Koulutus'
+   |      $ref: '#/components/schemas/Koulutus'
    |      properties:
    |        toteutukset:
    |          type: array
@@ -45,8 +44,7 @@
 (def toteutus-response-schema
   "|    ToteutusResponse:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/Toteutus'
+   |      $ref: '#/components/schemas/Toteutus'
    |      properties:
    |        toteutukset:
    |          type: object
@@ -73,8 +71,7 @@
 (def hakukohde-response-schema
   "|    HakukohdeResponse:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/Hakukohde'
+   |      $ref: '#/components/schemas/Hakukohde'
    |      properties:
    |        valintaperustekuvaus:
    |          type: object
@@ -105,8 +102,7 @@
 (def haku-response-schema
   "|    HakuResponse:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/Haku'
+   |      $ref: '#/components/schemas/Haku'
    |      properties:
    |        koulutukset:
    |          type: array

--- a/src/konfo_backend/external/schema/search.clj
+++ b/src/konfo_backend/external/schema/search.clj
@@ -23,8 +23,7 @@
    |        nimi:
    |          type: object
    |          description: Koulutuksen näytettävä nimi eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        kielivalinta:
    |          type: array
    |          description: Kielet, joille koulutuksen nimi, kuvailutiedot ja muut tekstit on käännetty.
@@ -47,18 +46,15 @@
    |        koulutus:
    |          type: object
    |          description: Koulutuksen koodi uri ja nimi
-   |          allOf:
-   |            - $ref: '#/components/schemas/KoulutusKoodi'
+   |          $ref: '#/components/schemas/KoulutusKoodi'
    |        kuvaus:
    |          type: object
    |          description: Koulutuksen kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        organisaatio:
    |          type: object
    |          description: Koulutuksen luonut organisaatio
-   |          allOf:
-   |           - $ref: '#/components/schemas/Organisaatio'
+   |          $ref: '#/components/schemas/Organisaatio'
    |        ePerusteId:
    |          type: number
    |          description: Ammatillisen koulutuksen ePerusteen id.

--- a/src/konfo_backend/external/schema/toteutus.clj
+++ b/src/konfo_backend/external/schema/toteutus.clj
@@ -45,7 +45,7 @@
    |        metadata:
    |          type: object
    |          oneOf:
-   |            - $ref: '#/components/schemas/AmmToteutusMetadata'
+   |            - $ref: '#/components/schemas/AmmatillinenToteutusMetadata'
    |          example:
    |            tyyppi: amm
    |            kuvaus:

--- a/src/konfo_backend/external/schema/toteutus.clj
+++ b/src/konfo_backend/external/schema/toteutus.clj
@@ -80,11 +80,10 @@
    |                fi: Maksullisuuden suomenkielinen kuvaus
    |                sv: Maksullisuuden ruotsinkielinen kuvaus
    |              maksunMaara: 200.50
-   |              alkamiskausiKoodiUri: kausi_k#1
-   |              alkamisvuosi : 2020
-   |              alkamisaikaKuvaus:
-   |                fi: Alkamisajan suomenkielinen kuvaus
-   |                sv: Alkamisajan ruotsinkielinen kuvaus
+   |              koulutuksenAlkamiskausiUUSI:
+   |                - alkamiskausityyppi : 'tarkka alkamisajankohta'
+   |                - koulutuksenAlkamispaivamaara: 2019-11-20T12:00
+   |                - koulutuksenPaattymispaivamaara: 2019-12-20T12:00
    |              lisatiedot:
    |                - otsikkoKoodiUri: koulutuksenlisatiedot_03#1
    |                  teksti:

--- a/src/konfo_backend/external/schema/toteutus.clj
+++ b/src/konfo_backend/external/schema/toteutus.clj
@@ -40,8 +40,7 @@
    |        nimi:
    |          type: object
    |          description: Toteutuksen näytettävä nimi eri kielillä. Kielet on määritetty toteutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        metadata:
    |          type: object
    |          oneOf:
@@ -134,8 +133,7 @@
    |        organisaatio:
    |          type: object
    |          description: Toteutuksen luonut organisaatio
-   |          allOf:
-   |           - $ref: '#/components/schemas/Organisaatio'
+   |          $ref: '#/components/schemas/Organisaatio'
    |        teemakuva:
    |          type: string
    |          description: Toteutuksen teemakuvan URL.

--- a/src/konfo_backend/external/schema/toteutus_metadata.clj
+++ b/src/konfo_backend/external/schema/toteutus_metadata.clj
@@ -247,13 +247,11 @@
    |        linkki:
    |          type: object
    |          description: Osaamisalan linkki ePerusteisiin
-   |          allOf:
-   |            - $ref: '#/components/schemas/Linkki'
+   |          $ref: '#/components/schemas/Linkki'
    |        otsikko:
    |          type: object
    |          description: Osaamisalan linkin otsikko eri kielillä
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def AmmOsaamisala
   {:koodi   (->Koodi #"osaamisala_\d+(#\d{1,2})?$")

--- a/src/konfo_backend/external/schema/toteutus_metadata.clj
+++ b/src/konfo_backend/external/schema/toteutus_metadata.clj
@@ -18,8 +18,7 @@
    |        opetuskieletKuvaus:
    |          type: object
    |          description: Koulutuksen toteutuksen opetuskieliä tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        opetusaika:
    |          type: array
    |          description: Lista koulutuksen toteutuksen opetusajoista
@@ -29,8 +28,7 @@
    |        opetusaikaKuvaus:
    |          type: object
    |          description: Koulutuksen toteutuksen opetusaikoja tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        opetustapa:
    |          type: array
    |          description: Lista koulutuksen toteutuksen opetustavoista
@@ -40,16 +38,14 @@
    |        opetustapaKuvaus:
    |          type: object
    |          description: Koulutuksen toteutuksen opetustapoja tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        onkoMaksullinen:
    |          type: boolean
    |          decription: Onko koulutus maksullinen?
    |        maksullisuusKuvaus:
    |          type: object
    |          description: Koulutuksen toteutuksen maksullisuutta tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        maksunMaara:
    |          type: double
    |          description: Koulutuksen toteutuksen maksun määrä euroissa?
@@ -94,8 +90,7 @@
    |        stipendinKuvaus:
    |          type: object
    |          description: Koulutuksen toteutuksen stipendiä tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        suunniteltuKestoVuodet:
    |          type: integer
    |          description: Koulutuksen suunniteltu kesto vuosina
@@ -107,8 +102,7 @@
    |        suunniteltuKestoKuvaus:
    |          type: object
    |          description: Koulutuksen suunnitellun keston kuvaus eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'")
+   |          $ref: '#/components/schemas/Kuvaus'")
 
 (def Opetus
   {:opetuskieli                                      [(->Koodi OpetuskieliKoodi)]
@@ -141,23 +135,19 @@
    |        nimi:
    |          type: object
    |          description: Korkeakoulututkinnon erikoistumisalan, opintosuunnan, pääaineen tms. nimi
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        kuvaus:
    |          type: object
    |          description: Korkeakoulututkinnon erikoistumisalan, opintosuunnan, pääaineen tms. kuvaus
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        linkki:
    |          type: object
    |          description: Korkeakoulututkinnon erikoistumisalan, opintosuunnan, pääaineen tms. linkki
-   |          allOf:
-   |            - $ref: '#/components/schemas/Linkki'
+   |          $ref: '#/components/schemas/Linkki'
    |        otsikko:
    |          type: object
    |          description: Korkeakoulututkinnon erikoistumisalan, opintosuunnan, pääaineen tms. linkin otsikko
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def KorkeakouluOsaamisala
   {:nimi    Kielistetty
@@ -246,8 +236,7 @@
    |          nimi:
    |            type: object
    |            description: Osaamisalan nimi eri kielillä
-   |            allOf:
-   |              - $ref: '#/components/schemas/Nimi'
+   |            $ref: '#/components/schemas/Nimi'
    |        linkki:
    |          type: object
    |          description: Osaamisalan linkki ePerusteisiin
@@ -287,8 +276,7 @@
    |        kieli:
    |          type: string
    |          desciption: Asiasanan kieli
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kieli'
+   |          $ref: '#/components/schemas/Kieli'
    |          example: fi
    |        arvo:
    |          type: string
@@ -302,8 +290,7 @@
    |        kieli:
    |          type: string
    |          desciption: Ammattinimikkeen kieli
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kieli'
+   |          $ref: '#/components/schemas/Kieli'
    |          example: fi
    |        arvo:
    |          type: string

--- a/src/konfo_backend/external/schema/toteutus_metadata.clj
+++ b/src/konfo_backend/external/schema/toteutus_metadata.clj
@@ -54,6 +54,10 @@
    |          type: double
    |          description: Koulutuksen toteutuksen maksun määrä euroissa?
    |          example: 220.50
+   |        koulutuksenAlkamiskausiUUSI:
+   |          type: object
+   |          description: Koulutuksen alkamiskausi
+   |          $ref: '#/components/schemas/KoulutuksenAlkamiskausi'
    |        koulutuksenTarkkaAlkamisaika:
    |          type: boolean
    |          description: Jos alkamisaika on tiedossa niin alkamis- ja päättymispäivämäärä on pakollinen. Muussa tapauksessa kausi ja vuosi on pakollisia tietoja.
@@ -116,6 +120,7 @@
    :onkoMaksullinen                                  s/Bool
    (s/->OptionalKey :maksullisuusKuvaus)             Kielistetty
    (s/->OptionalKey :maksunMaara)                    s/Num
+   (s/->OptionalKey :koulutuksenAlkamiskausiUUSI)    (s/maybe KoulutuksenAlkamiskausi)
    :koulutuksenTarkkaAlkamisaika                     s/Bool
    (s/->OptionalKey :koulutuksenAlkamispaivamaara)   Datetime
    (s/->OptionalKey :koulutuksenPaattymispaivamaara) Datetime

--- a/src/konfo_backend/external/schema/toteutus_metadata.clj
+++ b/src/konfo_backend/external/schema/toteutus_metadata.clj
@@ -263,13 +263,13 @@
 (def amm-toteutus-metadata-schema
   "|    AmmatillinenToteutusMetadata:
    |      allOf:
-   |        - $ref: '#/components/schemas/KoulutusMetadata'
+   |        - $ref: '#/components/schemas/ToteutusMetadata'
    |        - type: object
    |          properties:
    |            osaamisalat:
    |              type: array
    |              items:
-   |                $ref: '#/components/schemas/Osaamisala'
+   |                $ref: '#/components/schemas/AmmOsaamisala'
    |              description: Lista ammatillisen koulutuksen osaamisalojen kuvauksia
    |            koulutustyyppi:
    |              type: string

--- a/src/konfo_backend/external/schema/toteutus_metadata.clj
+++ b/src/konfo_backend/external/schema/toteutus_metadata.clj
@@ -167,8 +167,7 @@
    |        kuvaus:
    |          type: object
    |          description: Toteutuksen kuvausteksti eri kielillä. Kielet on määritetty toteutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        opetus:
    |          type: object
    |          $ref: '#/components/schemas/Opetus'

--- a/src/konfo_backend/external/schema/valintakoe.clj
+++ b/src/konfo_backend/external/schema/valintakoe.clj
@@ -41,6 +41,10 @@
    |          type: object
    |          description: Tietoa valintakokeesta
    |          $ref: '#/components/schemas/Teksti'
+   |        vahimmaispisteet:
+   |          type: double
+   |          description: Valintakokeen vähimmäispisteet
+   |          example: 10.0
    |        liittyyEnnakkovalmistautumista:
    |          type: boolean
    |          description: Liittyykö valintakokeeseen ennakkovalmistautumista
@@ -58,6 +62,7 @@
 
 (def ValintakoeMetadata
   {(s/->OptionalKey :tietoja)                        Kielistetty
+   (s/->OptionalKey :vahimmaispisteet)               s/Num
    (s/->OptionalKey :liittyyEnnakkovalmistautumista) s/Bool
    (s/->OptionalKey :ohjeetEnnakkovalmistautumiseen) Kielistetty
    (s/->OptionalKey :erityisjarjestelytMahdollisia)  s/Bool

--- a/src/konfo_backend/external/schema/valintakoe.clj
+++ b/src/konfo_backend/external/schema/valintakoe.clj
@@ -12,8 +12,7 @@
    |        osoite:
    |          type: object
    |          description: Valintakokeen järjestämispaikan osoite
-   |          allOf:
-   |            - $ref: '#/components/schemas/Osoite'
+   |          $ref: '#/components/schemas/Osoite'
    |        aika:
    |          type: array
    |          description: Valintakokeen järjestämisaika
@@ -22,13 +21,11 @@
    |        jarjestamispaikka:
    |          type: object
    |          description: Valintakokeen järjestämispaikka eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'
+   |          $ref: '#/components/schemas/Teksti'
    |        lisatietoja:
    |          type: object
    |          description: Lisätietoja valintakokeesta eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def ValintakoeTilaisuus
   {:osoite                              Osoite
@@ -43,24 +40,21 @@
    |        tietoja:
    |          type: object
    |          description: Tietoa valintakokeesta
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'
+   |          $ref: '#/components/schemas/Teksti'
    |        liittyyEnnakkovalmistautumista:
    |          type: boolean
    |          description: Liittyykö valintakokeeseen ennakkovalmistautumista
    |        ohjeetEnnakkovalmistautumiseen:
    |          type: object
    |          description: Ohjeet valintakokeen ennakkojärjestelyihin
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'
+   |          $ref: '#/components/schemas/Teksti'
    |        erityisjarjestelytMahdollisia:
    |          type: boolean
    |          description: Ovatko erityisjärjestelyt mahdollisia valintakokeessa
    |        ohjeetErityisjarjestelyihin:
    |          type: object
    |          description: Ohjeet valintakokeen erityisjärjestelyihin
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def ValintakoeMetadata
   {(s/->OptionalKey :tietoja)                        Kielistetty
@@ -85,8 +79,7 @@
    |        nimi:
    |          type: object
    |          description: Valintakokeen nimi eri kielillä. Kielet on määritetty kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        metadata:
    |          type: object
    |          $ref: '#/components/schemas/ValintakoeMetadata'

--- a/src/konfo_backend/external/schema/valintaperustekuvaus.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus.clj
@@ -58,8 +58,7 @@
    |        nimi:
    |          type: object
    |          description: Valintaperustekuvauksen Opintopolussa näytettävä nimi eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        valintakokeet:
    |          type: array
    |          description: Hakuun liittyvät valintakokeet
@@ -121,8 +120,7 @@
    |        organisaatio:
    |          type: object
    |          description: Valintaperustekuvauksen luoneen organisaation oid
-   |          allOf:
-   |            - $ref: '#/components/schemas/Organisaatio'
+   |          $ref: '#/components/schemas/Organisaatio'
    |        modified:
    |          type: string
    |          format: date-time

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -27,7 +27,15 @@
    |        kuvaus:
    |          type: object
    |          description: Valintaperusteen kuvaus eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |          $ref: '#/components/schemas/Kuvaus'")
+   |          $ref: '#/components/schemas/Kuvaus'
+   |        sisalto:
+   |          type: array
+   |          description: Valintaperusteen kuvauksen sisältö. Voi sisältää sekä teksti- että taulukkoelementtejä.
+   |          items:
+   |            type: object
+   |            oneOf:
+   |              - $ref: '#/components/schemas/SisaltoTeksti'
+   |              - $ref: '#/components/schemas/SisaltoTaulukko'")
 
 (def kielitaitovaatimus-schema
   "|    Kielitaitovaatimus:

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -38,7 +38,7 @@
    |          description: Kielitaitovaatimuksen kieli
    |          $ref: '#/components/schemas/KielitaitovaatimusKieli'
    |        kielitaidonVoiOsoittaa:
-   |         type: array
+   |          type: array
    |          description: Lista tavoista, joilla kielitaidon voi osoittaa
    |          items:
    |            type: object
@@ -96,10 +96,10 @@
    |          type: array
    |          description: Valintatavan sisältö. Voi sisältää sekä teksti- että taulukkoelementtejä.
    |          items:
-   |          type: object
-   |          oneOf:
-   |            - $ref: '#/components/schemas/ValintatapaSisaltoTeksti'
-   |            - $ref: '#/components/schemas/ValintatapaSisaltoTaulukko'
+   |            type: object
+   |            oneOf:
+   |              - $ref: '#/components/schemas/ValintatapaSisaltoTeksti'
+   |              - $ref: '#/components/schemas/ValintatapaSisaltoTaulukko'
    |        kaytaMuuntotaulukkoa:
    |          type: boolean
    |          description: Käytetäänkö muuntotaulukkoa?

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -50,8 +50,7 @@
    |              lisatieto:
    |                type: object
    |                description: Kielitaidon osoittamisen lisätieto eri kielillä.
-   |                allOf:
-   |                  - $ref: '#/components/schemas/Teksti'
+   |                $ref: '#/components/schemas/Teksti'
    |        vaatimukset:
    |          type: array
    |          description: Lista kielitaitovaatimuksista

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -70,7 +70,7 @@
    |                    kielitaitovaatimusKuvaus:
    |                      type: string
    |                      description: Kielitaitovaatimuksen kuvaus
-   |                      $ref: '#/components/schemas/KielitaitovaatimusTyyppiKuvaus'
+   |                      $ref: '#/components/schemas/KielitaitovaatimusTyypinKuvaus'
    |                    kielitaitovaatimusTaso:
    |                      type: string
    |                      description: Kielitaitovaatimuksen taso

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -169,9 +169,9 @@
    |            - amk")
 
 (def valintatapa-sisalto-teksti-schema
-  "|    ValintatapaSisaltoTeksti:
+  "|    SisaltoTeksti:
    |      type: object
-   |      description: Tekstimuotoinen valintatavan sisällön kuvaus
+   |      description: Tekstimuotoinen sisällön kuvaus
    |      properties:
    |        tyyppi:
    |          type: string
@@ -187,7 +187,7 @@
 (def valintatapa-sisalto-taulukko-schema
   "|    ValintatapaSisaltoTaulukko:
    |      type: object
-   |      description: Taulukkomuotoinen valintatavan sisällön kuvaus
+   |      description: Taulukkomuotoinen sisällön kuvaus
    |      properties:
    |        tyyppi:
    |          type: string
@@ -249,7 +249,7 @@
                                                (s/->OptionalKey :kielitaitovaatimusKuvaukset) [{(s/->OptionalKey :kielitaitovaatimusKuvaus) (s/maybe (->Koodi KielitaitovaatimusTyypinKuvausKoodi))
                                                                                                 (s/->OptionalKey :kielitaitovaatimusTaso)   (s/maybe s/Str)}]}]})
 
-(def ValintatapaSisaltoTeksti
+(def SisaltoTeksti
   {:tyyppi                   (s/eq "teksti")
    (s/->OptionalKey :data)   Kielistetty})
 
@@ -265,7 +265,7 @@
   {:valintatapa                            (->Koodi ValintatapaKoodi)
    (s/->OptionalKey :nimi)                 Kielistetty
    (s/->OptionalKey :kuvaus)               Kielistetty
-   (s/->OptionalKey :sisalto)              [(s/if #(= "taulukko" (:tyyppi %)) ValintatapaSisaltoTaulukko ValintatapaSisaltoTeksti)]
+   (s/->OptionalKey :sisalto)              [(s/if #(= "taulukko" (:tyyppi %)) ValintatapaSisaltoTaulukko SisaltoTeksti)]
    (s/->OptionalKey :kaytaMuuntotaulukkoa) (s/maybe s/Bool)
    (s/->OptionalKey :kynnysehto)           Kielistetty
    (s/->OptionalKey :enimmaispisteet)      (s/maybe s/Num)
@@ -274,6 +274,7 @@
 (def ValintaperusteKuvausMetadata
    {(s/->OptionalKey :valintatavat)               [Valintatapa]
     (s/->OptionalKey :kielitaitovaatimukset)      [Kielitaitovaatimus]
+    (s/->OptionalKey :sisalto)                    [(s/if #(= "taulukko" (:tyyppi %)) ValintatapaSisaltoTaulukko SisaltoTeksti)]
     (s/->OptionalKey :kuvaus)                     Kielistetty
     (s/->OptionalKey :valintakokeidenYleiskuvaus) Kielistetty})
 

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -98,8 +98,8 @@
    |          items:
    |            type: object
    |            oneOf:
-   |              - $ref: '#/components/schemas/ValintatapaSisaltoTeksti'
-   |              - $ref: '#/components/schemas/ValintatapaSisaltoTaulukko'
+   |              - $ref: '#/components/schemas/SisaltoTeksti'
+   |              - $ref: '#/components/schemas/SisaltoTaulukko'
    |        kaytaMuuntotaulukkoa:
    |          type: boolean
    |          description: Käytetäänkö muuntotaulukkoa?
@@ -185,7 +185,7 @@
    |          $ref: '#/components/schemas/Teksti'")
 
 (def valintatapa-sisalto-taulukko-schema
-  "|    ValintatapaSisaltoTaulukko:
+  "|    SisaltoTaulukko:
    |      type: object
    |      description: Taulukkomuotoinen sisällön kuvaus
    |      properties:
@@ -253,7 +253,7 @@
   {:tyyppi                   (s/eq "teksti")
    (s/->OptionalKey :data)   Kielistetty})
 
-(def ValintatapaSisaltoTaulukko
+(def SisaltoTaulukko
   {:tyyppi                   (s/eq "taulukko")
    (s/->OptionalKey :data)   {(s/->OptionalKey :nimi) Kielistetty
                               :rows                   [{:index s/Num
@@ -265,7 +265,7 @@
   {:valintatapa                            (->Koodi ValintatapaKoodi)
    (s/->OptionalKey :nimi)                 Kielistetty
    (s/->OptionalKey :kuvaus)               Kielistetty
-   (s/->OptionalKey :sisalto)              [(s/if #(= "taulukko" (:tyyppi %)) ValintatapaSisaltoTaulukko SisaltoTeksti)]
+   (s/->OptionalKey :sisalto)              [(s/if #(= "taulukko" (:tyyppi %)) SisaltoTaulukko SisaltoTeksti)]
    (s/->OptionalKey :kaytaMuuntotaulukkoa) (s/maybe s/Bool)
    (s/->OptionalKey :kynnysehto)           Kielistetty
    (s/->OptionalKey :enimmaispisteet)      (s/maybe s/Num)
@@ -274,7 +274,7 @@
 (def ValintaperusteKuvausMetadata
    {(s/->OptionalKey :valintatavat)               [Valintatapa]
     (s/->OptionalKey :kielitaitovaatimukset)      [Kielitaitovaatimus]
-    (s/->OptionalKey :sisalto)                    [(s/if #(= "taulukko" (:tyyppi %)) ValintatapaSisaltoTaulukko SisaltoTeksti)]
+    (s/->OptionalKey :sisalto)                    [(s/if #(= "taulukko" (:tyyppi %)) SisaltoTaulukko SisaltoTeksti)]
     (s/->OptionalKey :kuvaus)                     Kielistetty
     (s/->OptionalKey :valintakokeidenYleiskuvaus) Kielistetty})
 

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -23,13 +23,11 @@
    |        valintakokeidenYleiskuvaus:
    |          type: object
    |          description: Valintakokeiden yleiskuvaus eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus')
+   |          $ref: '#/components/schemas/Kuvaus'
    |        kuvaus:
    |          type: object
    |          description: Valintaperusteen kuvaus eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'")
+   |          $ref: '#/components/schemas/Kuvaus'")
 
 (def kielitaitovaatimus-schema
   "|    Kielitaitovaatimus:
@@ -90,13 +88,11 @@
    |        nimi:
    |          type: object
    |          description: Valintatapakuvauksen Opintopolussa näytettävä nimi eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Nimi'
+   |          $ref: '#/components/schemas/Nimi'
    |        kuvaus:
    |          type: object
    |          description: Valintatavan kuvausteksti eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        sisalto:
    |          type: array
    |          description: Valintatavan sisältö. Voi sisältää sekä teksti- että taulukkoelementtejä.
@@ -111,8 +107,7 @@
    |        kynnysehto:
    |          type: object
    |          description: Kynnysehdon kuvausteksti eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'
+   |          $ref: '#/components/schemas/Kuvaus'
    |        enimmaispisteet:
    |          type: double
    |          description: Valintatavan enimmäispisteet
@@ -125,8 +120,7 @@
 (def amm-valintaperustekuvaus-metadata-schema
   "|    AmmValintaperustekuvausMetadata:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/ValintaperustekuvausMetadata'
+   |      $ref: '#/components/schemas/ValintaperustekuvausMetadata'
    |      properties:
    |        tyyppi:
    |          type: string
@@ -138,8 +132,7 @@
 (def korkeakoulutus-valintaperustekuvaus-metadata-schema
   "|    KorkeakoulutusValintaperustekuvausMetadata:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/ValintaperustekuvausMetadata'
+   |      $ref: '#/components/schemas/ValintaperustekuvausMetadata'
    |      properties:
    |        osaamistaustat:
    |          type: array
@@ -150,14 +143,12 @@
    |        kuvaus:
    |          type: object
    |          description: Valintaperustekuvauksen kuvausteksti eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Kuvaus'")
+   |          $ref: '#/components/schemas/Kuvaus'")
 
 (def yo-valintaperustekuvaus-metadata-schema
   "|    YoValintaperustekuvausMetadata:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/KorkeakoulutusValintaperustekuvausMetadata'
+   |      $ref: '#/components/schemas/KorkeakoulutusValintaperustekuvausMetadata'
    |      properties:
    |        tyyppi:
    |          type: string
@@ -169,8 +160,7 @@
 (def amk-valintaperustekuvaus-metadata-schema
   "|    AmkValintaperustekuvausMetadata:
    |      type: object
-   |      allOf:
-   |        - $ref: '#/components/schemas/KorkeakoulutusValintaperustekuvausMetadata'
+   |      $ref: '#/components/schemas/KorkeakoulutusValintaperustekuvausMetadata'
    |      properties:
    |        tyyppi:
    |          type: string
@@ -193,8 +183,7 @@
    |        data:
    |          type: object
    |          description: Sisältöteksti eri kielillä.
-   |          allOf:
-   |            - $ref: '#/components/schemas/Teksti'")
+   |          $ref: '#/components/schemas/Teksti'")
 
 (def valintatapa-sisalto-taulukko-schema
   "|    ValintatapaSisaltoTaulukko:
@@ -214,8 +203,7 @@
    |            nimi:
    |              type: object
    |              description: Taulukon Opintopolussa näytettävä nimi eri kielillä. Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |              allOf:
-   |                - $ref: '#/components/schemas/Nimi'
+   |              $ref: '#/components/schemas/Nimi'
    |            rows:
    |              type: array
    |              description: Taukon rivit
@@ -241,8 +229,7 @@
    |                          type: object
    |                          description: Sarakkeen Opintopolussa näytettävä teksti eri kielillä.
    |                            Kielet on määritetty valintaperustekuvauksen kielivalinnassa.
-   |                          allOf:
-   |                            - $ref: '#/components/schemas/Teksti'")
+   |                          $ref: '#/components/schemas/Teksti'")
 
 (def schemas
   (str valintatapa-sisalto-teksti-schema "\n"


### PR DESCRIPTION
- Lisätty kouta-backendin tietomalliin tulleet muutokset external rajapintoihin
- Korjattu liuta swagger-skeemaa hajottaneita typoja, vääriä sisennyksiä, väärien skeemojen käyttöjä. Näiden korjausten myötä swaggerin ei pitäisi enää heittää virheitä.
- Siivottu tarpeettomia allOf määritteitä swagger-skeemasta. Allofia tarvitsee käyttää vain jos entiteetin skeema on yhdiste useammasta kuin yhdestä skeemasta
- Nostettu kouta-backendin versio