### PR TITLE
Kto 1145

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
                    :jvm-opts ["-Dport=3006"]}
              :updater {:jvm-opts ["-Dmode=updater" "-Dport=3006"]}
              :test {:dependencies [[ring/ring-mock "0.3.2"]
-                                   [kouta-indeksoija-service "7.1.0-SNAPSHOT"]
+                                   [kouta-indeksoija-service "7.4.0-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "6.3.0-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "6.3.0-SNAPSHOT" :classifier "tests"]
                                    [fi.oph.kouta/kouta-common "2.2.0-SNAPSHOT" :classifier "tests"]
@@ -56,7 +56,7 @@
                     :injections [(require '[clj-test-utils.elasticsearch-docker-utils :as utils])
                                  (utils/global-docker-elastic-fixture)]}
              :ci-test {:dependencies [[ring/ring-mock "0.3.2"]
-                                      [kouta-indeksoija-service "7.1.0-SNAPSHOT"]
+                                      [kouta-indeksoija-service "7.4.0-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "6.3.0-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "6.3.0-SNAPSHOT" :classifier "tests"]
                                       [fi.oph.kouta/kouta-common "2.2.0-SNAPSHOT" :classifier "tests"]

--- a/src/konfo_backend/elastic_tools.clj
+++ b/src/konfo_backend/elastic_tools.clj
@@ -7,10 +7,12 @@
     [clojure.tools.logging :as log]))
 
 (defn get-source
-  [index id]
-  (let [result (e/get-document index id)]
-    (when (:found result)
-      (:_source result))))
+  ([index id excludes]
+   (let [result (e/get-document index id :_source_excludes (clojure.string/join "," excludes))]
+     (when (:found result)
+       (:_source result))))
+  ([index id]
+   (get-source index id [])))
 
 (defn get-sources
   [index ids excludes]

--- a/src/konfo_backend/external/schema/koulutus.clj
+++ b/src/konfo_backend/external/schema/koulutus.clj
@@ -131,7 +131,8 @@
    :nimi                         Kielistetty
    :metadata                     (s/conditional #(= "amm" (:tyyppi %)) AmmKoulutusMetadata
                                                 #(= "yo" (:tyyppi %)) YoMetadata
-                                                #(= "amk" (:tyyppi %)) AmkMetadata)
+                                                #(= "amk" (:tyyppi %)) AmkMetadata
+                                                #(= "lk" (:tyyppi %)) LukioKoulutusMetadata )
    :organisaatio                 Organisaatio
    (s/->OptionalKey :teemakuva)  Url
    (s/->OptionalKey :ePerusteId) s/Int

--- a/src/konfo_backend/external/schema/koulutus_metadata.clj
+++ b/src/konfo_backend/external/schema/koulutus_metadata.clj
@@ -113,6 +113,43 @@
     |              example: amk
     |              enum:
     |                - amk
+    |    LukioKoulutusMetadata:
+    |      type: object
+    |      properties:
+    |        koulutustyyppi:
+    |          type: string
+    |          description: Koulutuksen metatiedon tyyppi
+    |          example: lk
+    |          enum:
+    |            - lk
+    |        kuvaus:
+    |          type: object
+    |          description: Koulutuksen kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
+    |          $ref: '#/components/schemas/Kuvaus'
+    |        lisatiedot:
+    |          type: array
+    |          description: Koulutukseen liittyviä lisätietoja, jotka näkyvät oppijalle
+    |          items:
+    |            type: object
+    |            $ref: '#/components/schemas/KoulutusLisatieto'
+    |        koulutusala:
+    |          type: array
+    |          description: Lista koulutuksen koulutusaloista
+    |          items:
+    |            type: object
+    |            $ref: '#/components/schemas/Koulutusala1'
+    |        opintojenLaajuus:
+    |          type: object
+    |          $ref: '#/components/schemas/OpintojenLaajuus'
+    |        opintojenLaajuusyksikko:
+    |          type: object
+    |          $ref: '#/components/schemas/OpintojenLaajuusyksikko'
+    |        tutkintonimike:
+    |          type: array
+    |          description: Lista koulutuksen tutkintonimikkeistä
+    |          items:
+    |            type: object
+    |            $ref: '#/components/schemas/Tutkintonimike'
     |"
   )
 

--- a/src/konfo_backend/external/schema/koulutus_metadata.clj
+++ b/src/konfo_backend/external/schema/koulutus_metadata.clj
@@ -151,3 +151,12 @@
   (st/merge
     {:tyyppi Yo}
     KkMetadata))
+
+(def LukioKoulutusMetadata
+  {:tyyppi                                    Lk
+   :kuvaus                                    Kielistetty
+   :lisatiedot                                [KoulutusLisatieto]
+   :koulutusala                               [(->Koodi Koulutusala1Koodi)]
+   (s/->OptionalKey :opintojenLaajuus)        (s/maybe (->Koodi OpintojenLaajuusKoodi))
+   :opintojenLaajuusyksikko                   (->Koodi OpintojenLaajuusyksikkoKoodi)
+   :tutkintonimike                            (->Koodi TutkintonimikeKoodi)})

--- a/src/konfo_backend/external/schema/koulutus_metadata.clj
+++ b/src/konfo_backend/external/schema/koulutus_metadata.clj
@@ -62,9 +62,18 @@
     |          type: object
     |          $ref: '#/components/schemas/Eperuste'
     |    KorkeakouluMetadata:
-    |      allOf:
-    |        - $ref: '#/components/schemas/KoulutusMetadata'
+    |      type: object
     |      properties:
+    |        kuvaus:
+    |          type: object
+    |          description: Koulutuksen kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
+    |          $ref: '#/components/schemas/Kuvaus'
+    |        lisatiedot:
+    |          type: array
+    |          description: Koulutukseen liittyviä lisätietoja, jotka näkyvät oppijalle
+    |          items:
+    |            type: object
+    |            $ref: '#/components/schemas/KoulutusLisatieto'
     |        kuvauksenNimi:
     |          type: object
     |          description: Koulutuksen kuvaukseni nimi eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.

--- a/src/konfo_backend/external/service.clj
+++ b/src/konfo_backend/external/service.clj
@@ -60,14 +60,14 @@
 (defn- get-hakukohteet-by-toteutus-oids
   [toteutusOids]
   (when (seq toteutusOids)
-    (->> (hakukohde/get-many-by-terms :toteutusOid toteutusOids ["toteutus" "muokkaaja" "yhdenPaikanSaanto" "valintaperuste" "hakulomakeAtaruId" "esikatselu"])
+    (->> (hakukohde/get-many-by-terms :toteutusOid toteutusOids ["toteutus" "muokkaaja" "yhdenPaikanSaanto" "valintaperuste" "hakulomakeAtaruId" "esikatselu" "koulutustyypit" "sora"])
          (filter julkaistu?)
          (vec))))
 
 (defn- get-hakukohteet
   [oids]
   (when (seq oids)
-    (->> (hakukohde/get-many oids ["toteutus" "muokkaaja" "yhdenPaikanSaanto" "valintaperuste" "hakulomakeAtaruId" "esikatselu"])
+    (->> (hakukohde/get-many oids ["toteutus" "muokkaaja" "yhdenPaikanSaanto" "valintaperuste" "hakulomakeAtaruId" "esikatselu" "koulutustyypit" "sora"])
          (filter julkaistu?)
          (vec))))
 

--- a/src/konfo_backend/index/hakukohde.clj
+++ b/src/konfo_backend/index/hakukohde.clj
@@ -8,7 +8,8 @@
 
 (defn get
   [oid draft?]
-  (let [hakukohde (get-source index oid)]
+  (let [excludes ["koulutustyypit" "sora"]
+        hakukohde (get-source index oid excludes)]
     (when (allowed-to-view hakukohde draft?)
       (if (allowed-to-view (:valintaperuste hakukohde) draft?)
         hakukohde

--- a/test/konfo_backend/external/external_api_test.clj
+++ b/test/konfo_backend/external/external_api_test.clj
@@ -42,11 +42,9 @@
           hakuOid1       "1.2.246.562.29.000001"
           hakuOid2       "1.2.246.562.29.000002"
           kkHakuOid      "1.2.246.562.29.000099"
-          kkSorakuvausId     "2ff6700d-087f-4dbf-9e42-7f38948f227a"
           sorakuvausId       "a5e88367-555b-4d9e-aa43-0904e5ea0a13"
           valintaperusteId1  "2d0651b7-cdd3-463b-80d9-303a60d9616c"
-          valintaperusteId2  "45d2ae02-9a5f-42ef-8148-47d07737927b"
-          kkValintaperusteId "ffa8c6cf-a962-4bb2-bf61-fe8fc741fabd"]
+          valintaperusteId2  "45d2ae02-9a5f-42ef-8148-47d07737927b"]
 
       (fixture/add-koulutus-mock koulutusOid1 :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1 :sorakuvausId sorakuvausId)
       (fixture/add-koulutus-mock koulutusOid2 :tila "tallennettu" :nimi "Hupaisa julkaisematon koulutus" :organisaatio mocks/Oppilaitos2 :sorakuvausId sorakuvausId)
@@ -67,10 +65,8 @@
       (fixture/add-hakukohde-mock kkHakukohdeOid kkToteutusOid kkHakuOid :tila "julkaistu" :valintaperuste valintaperusteId2)
 
       (fixture/add-sorakuvaus-mock sorakuvausId :tila "julkaistu")
-      ;(fixture/add-sorakuvaus-mock kkSorakuvausId :tila "julkaistu" :koulutustyyppi "yo" :metadata "{}")
       (fixture/add-valintaperuste-mock valintaperusteId1 :tila "julkaistu")
       (fixture/add-valintaperuste-mock valintaperusteId2 :tila "tallennettu")
-      ;(fixture/add-valintaperuste-mock kkValintaperusteId :tila "julkaistu" :koulutustyyppi "yo" :sorakuvaus kkSorakuvausId :metadata "{}")
 
       (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 kkKoulutusOid]
                                                    :toteutukset [toteutusOid1 toteutusOid2 toteutusOid3 kkToteutusOid]

--- a/test/konfo_backend/external/external_api_test.clj
+++ b/test/konfo_backend/external/external_api_test.clj
@@ -5,7 +5,7 @@
             [kouta-indeksoija-service.fixture.kouta-indexer-fixture :as fixture]
             [kouta-indeksoija-service.fixture.external-services :as mocks]
             [konfo-backend.test-tools :refer :all]
-            [konfo-backend.search.search-test-tools :refer [yo-koulutus-metatieto yo-toteutus-metatieto]]))
+            [konfo-backend.search.search-test-tools :refer [yo-koulutus-metatieto lukio-koulutus-metatieto yo-toteutus-metatieto]]))
 
 (intern 'clj-log.access-log 'service "konfo-backend")
 
@@ -31,6 +31,7 @@
   (testing "Testing external apis"
     (let [koulutusOid1   "1.2.246.562.13.000001"
           koulutusOid2   "1.2.246.562.13.000002"
+          lukio-Oid      "1.2.246.562.13.000003"
           kkKoulutusOid  "1.2.246.562.13.000099"
           toteutusOid1   "1.2.246.562.17.000001"
           toteutusOid2   "1.2.246.562.17.000002"
@@ -48,6 +49,7 @@
 
       (fixture/add-koulutus-mock koulutusOid1 :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1 :sorakuvausId sorakuvausId)
       (fixture/add-koulutus-mock koulutusOid2 :tila "tallennettu" :nimi "Hupaisa julkaisematon koulutus" :organisaatio mocks/Oppilaitos2 :sorakuvausId sorakuvausId)
+      (fixture/add-koulutus-mock lukio-Oid :tila "julkaistu" :koulutustyyppi "lk" :nimi "Lukio koulutus" :organisaatio mocks/Oppilaitos2 :metadata lukio-koulutus-metatieto :sorakuvausId sorakuvausId :ePerusteId nil)
       (fixture/add-koulutus-mock kkKoulutusOid :tila "julkaistu" :koulutustyyppi "yo" :nimi "YO koulutus" :organisaatio mocks/Oppilaitos2 :metadata yo-koulutus-metatieto :sorakuvausId sorakuvausId)
 
       (fixture/add-toteutus-mock toteutusOid1 koulutusOid1 :tila "julkaistu")
@@ -68,7 +70,7 @@
       (fixture/add-valintaperuste-mock valintaperusteId1 :tila "julkaistu")
       (fixture/add-valintaperuste-mock valintaperusteId2 :tila "tallennettu")
 
-      (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 kkKoulutusOid]
+      (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 kkKoulutusOid lukio-Oid]
                                                    :toteutukset [toteutusOid1 toteutusOid2 toteutusOid3 kkToteutusOid]
                                                    :haut [hakuOid1 hakuOid2 kkHakuOid]
                                                    :hakukohteet [hakukohdeOid1 hakukohdeOid2 kkHakukohdeOid]
@@ -78,6 +80,12 @@
         (testing "ok only koulutus"
           (let [response (get-ok-or-print-schema-error (koulutus-url koulutusOid1))]
             (is (= koulutusOid1 (:oid response)))
+            (is (false? (contains? response :toteutukset)))
+            (is (false? (contains? response :hakukohteet)))
+            (is (false? (contains? response :haut)))))
+        (testing "only lukio koulutus"
+          (let [response (get-ok-or-print-schema-error (koulutus-url lukio-Oid))]
+            (is (= lukio-Oid (:oid response)))
             (is (false? (contains? response :toteutukset)))
             (is (false? (contains? response :hakukohteet)))
             (is (false? (contains? response :haut)))))

--- a/test/konfo_backend/index/eperuste_test.clj
+++ b/test/konfo_backend/index/eperuste_test.clj
@@ -56,14 +56,14 @@
 
 (deftest eperuste-test
   (testing "Get eperuste-kuvaus"
-    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] mocked-response-voimassa)]
+    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y & z] mocked-response-voimassa)]
       (let [response (get-ok (kuvaus-url "3536456"))]
         (is (= response {:id 3536456,
                          :tyotehtavatJoissaVoiToimia  {:fi "työtehtävät fi" :sv "työtehtävät sv"},
                          :suorittaneenOsaaminen {:fi "osaaminen fi" :sv "osaaminen sv"}})))))
 
   (testing "Get eperuste-kuvaus with osaamisalakuvaukset"
-    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] mocked-response-voimassa)
+    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y & z] mocked-response-voimassa)
                   clj-elasticsearch.elastic-connect/search (fn [i y & z] mocked-osaamisala-response)]
       (let [response (get-ok (str (kuvaus-url "3536456") "?osaamisalakuvaukset=true"))]
         (is (= response {:id 3536456,
@@ -150,5 +150,5 @@
                           :tila "valmis"}])))))
 
   (testing "Don't get not valmis eperuste"
-    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] {:found true :_source {:id 3536456 :tila "luonnos" :voimassaoloAlkaa  (- (now-in-millis) 10000)}})]
+    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y & z] {:found true :_source {:id 3536456 :tila "luonnos" :voimassaoloAlkaa  (- (now-in-millis) 10000)}})]
       (get-not-found (eperuste-url 3536456)))))

--- a/test/konfo_backend/index/hakukohde_test.clj
+++ b/test/konfo_backend/index/hakukohde_test.clj
@@ -44,7 +44,6 @@
     (fixture/add-valintaperuste-mock valintaperusteId3 :tila "tallennettu" :esikatselu "true")
 
     (fixture/add-toteutus-mock toteutus-oid koulutus-oid)
-    (fixture/add-koulutus-mock koulutus-oid :sorakuvausId sorakuvaus-id)
     (fixture/add-haku-mock "1.2.246.562.29.000001")
     (fixture/add-sorakuvaus-mock sorakuvaus-id :tila "julkaistu")
 

--- a/test/konfo_backend/index/hakukohde_test.clj
+++ b/test/konfo_backend/index/hakukohde_test.clj
@@ -28,23 +28,23 @@
         valintaperusteId3 "45d2ae02-9a5f-42ef-8148-47d07737927b"
         sorakuvaus-id "8a52fbda-74bb-459b-a963-3403ba6e185b"
         toteutus-oid "1.2.246.562.17.000001"
-        koulutus-oid "1.2.246.562.13.000001"]
+        koulutus-oid "1.2.246.562.13.000001"
+        haku-oid "1.2.246.562.29.000001"]
 
-    (fixture/add-haku-mock "1.2.246.562.29.000001" :tila "julkaistu" :organisaatio mocks/Oppilaitos1)
+    (fixture/add-haku-mock haku-oid :tila "julkaistu" :organisaatio mocks/Oppilaitos1)
 
     (fixture/add-koulutus-mock koulutus-oid :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1 :sorakuvausId sorakuvaus-id)
 
-    (fixture/add-hakukohde-mock hakukohdeOid1 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
-    (fixture/add-hakukohde-mock hakukohdeOid2 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId2)
-    (fixture/add-hakukohde-mock hakukohdeOid3 toteutus-oid "1.2.246.562.29.000001" :tila "tallennettu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
-    (fixture/add-hakukohde-mock hakukohdeOid5 toteutus-oid "1.2.246.562.29.000001" :tila "tallennettu" :esikatselu "true" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId3)
+    (fixture/add-hakukohde-mock hakukohdeOid1 toteutus-oid haku-oid :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
+    (fixture/add-hakukohde-mock hakukohdeOid2 toteutus-oid haku-oid :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId2)
+    (fixture/add-hakukohde-mock hakukohdeOid3 toteutus-oid haku-oid :tila "tallennettu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
+    (fixture/add-hakukohde-mock hakukohdeOid5 toteutus-oid haku-oid :tila "tallennettu" :esikatselu "true" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId3)
 
     (fixture/add-valintaperuste-mock valintaperusteId1 :tila "julkaistu" :esikatselu "false")
     (fixture/add-valintaperuste-mock valintaperusteId2 :tila "tallennettu" :esikatselu "false")
     (fixture/add-valintaperuste-mock valintaperusteId3 :tila "tallennettu" :esikatselu "true")
 
     (fixture/add-toteutus-mock toteutus-oid koulutus-oid)
-    (fixture/add-haku-mock "1.2.246.562.29.000001")
     (fixture/add-sorakuvaus-mock sorakuvaus-id :tila "julkaistu")
 
     (fixture/index-oids-without-related-indices {:hakukohteet [hakukohdeOid1 hakukohdeOid2 hakukohdeOid3 hakukohdeOid5]})

--- a/test/konfo_backend/index/hakukohde_test.clj
+++ b/test/konfo_backend/index/hakukohde_test.clj
@@ -28,11 +28,12 @@
         valintaperusteId2 "3456ae02-9a5f-42ef-8148-47d077373333"
         valintaperusteId3 "45d2ae02-9a5f-42ef-8148-47d07737927b"
         sorakuvaus-id "8a52fbda-74bb-459b-a963-3403ba6e185b"
-        toteutus-oid "1.2.246.562.17.000001"]
+        toteutus-oid "1.2.246.562.17.000001"
+        koulutus-oid "1.2.246.562.13.000001"]
 
     (fixture/add-haku-mock "1.2.246.562.29.000001" :tila "julkaistu" :organisaatio mocks/Oppilaitos1)
 
-    (fixture/add-koulutus-mock "1.2.246.562.13.000001" :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1)
+    (fixture/add-koulutus-mock koulutus-oid :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1)
 
     (fixture/add-hakukohde-mock hakukohdeOid1 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
     (fixture/add-hakukohde-mock hakukohdeOid2 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId2)
@@ -43,8 +44,8 @@
     (fixture/add-valintaperuste-mock valintaperusteId2 :tila "tallennettu" :esikatselu "false")
     (fixture/add-valintaperuste-mock valintaperusteId3 :tila "tallennettu" :esikatselu "true")
 
-    (fixture/add-toteutus-mock toteutus-oid "1.2.246.562.13.000001")
-    (fixture/add-koulutus-mock "1.2.246.562.13.000001")
+    (fixture/add-toteutus-mock toteutus-oid koulutus-oid)
+    (fixture/add-koulutus-mock koulutus-oid)
     (fixture/add-haku-mock "1.2.246.562.29.000001")
     (fixture/add-sorakuvaus-mock sorakuvaus-id :tila "julkaistu")
 

--- a/test/konfo_backend/index/hakukohde_test.clj
+++ b/test/konfo_backend/index/hakukohde_test.clj
@@ -26,24 +26,27 @@
         hakukohdeOid5 "1.2.246.562.20.000005"
         valintaperusteId1 "2d0651b7-cdd3-463b-80d9-303a60d9616c"
         valintaperusteId2 "3456ae02-9a5f-42ef-8148-47d077373333"
-        valintaperusteId3 "45d2ae02-9a5f-42ef-8148-47d07737927b"]
+        valintaperusteId3 "45d2ae02-9a5f-42ef-8148-47d07737927b"
+        sorakuvaus-id "8a52fbda-74bb-459b-a963-3403ba6e185b"
+        toteutus-oid "1.2.246.562.17.000001"]
 
     (fixture/add-haku-mock "1.2.246.562.29.000001" :tila "julkaistu" :organisaatio mocks/Oppilaitos1)
 
     (fixture/add-koulutus-mock "1.2.246.562.13.000001" :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1)
 
-    (fixture/add-hakukohde-mock hakukohdeOid1 "1.2.246.562.17.000001" "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
-    (fixture/add-hakukohde-mock hakukohdeOid2 "1.2.246.562.17.000001" "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId2)
-    (fixture/add-hakukohde-mock hakukohdeOid3 "1.2.246.562.17.000001" "1.2.246.562.29.000001" :tila "tallennettu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
-    (fixture/add-hakukohde-mock hakukohdeOid5 "1.2.246.562.17.000001" "1.2.246.562.29.000001" :tila "tallennettu" :esikatselu "true" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId3)
+    (fixture/add-hakukohde-mock hakukohdeOid1 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
+    (fixture/add-hakukohde-mock hakukohdeOid2 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId2)
+    (fixture/add-hakukohde-mock hakukohdeOid3 toteutus-oid "1.2.246.562.29.000001" :tila "tallennettu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
+    (fixture/add-hakukohde-mock hakukohdeOid5 toteutus-oid "1.2.246.562.29.000001" :tila "tallennettu" :esikatselu "true" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId3)
 
     (fixture/add-valintaperuste-mock valintaperusteId1 :tila "julkaistu" :esikatselu "false")
     (fixture/add-valintaperuste-mock valintaperusteId2 :tila "tallennettu" :esikatselu "false")
     (fixture/add-valintaperuste-mock valintaperusteId3 :tila "tallennettu" :esikatselu "true")
 
-    (fixture/add-toteutus-mock "1.2.246.562.17.000001" "1.2.246.562.13.000001")
+    (fixture/add-toteutus-mock toteutus-oid "1.2.246.562.13.000001")
     (fixture/add-koulutus-mock "1.2.246.562.13.000001")
     (fixture/add-haku-mock "1.2.246.562.29.000001")
+    (fixture/add-sorakuvaus-mock sorakuvaus-id :tila "julkaistu")
 
     (fixture/index-oids-without-related-indices {:hakukohteet [hakukohdeOid1 hakukohdeOid2 hakukohdeOid3 hakukohdeOid5]})
 

--- a/test/konfo_backend/index/hakukohde_test.clj
+++ b/test/konfo_backend/index/hakukohde_test.clj
@@ -18,7 +18,6 @@
   (apply url-with-query-params (str "/konfo-backend/hakukohde/" oid) [:draft true]))
 
 (deftest hakukohde-test
-
   (let [hakukohdeOid1 "1.2.246.562.20.000001"
         hakukohdeOid2 "1.2.246.562.20.000002"
         hakukohdeOid3 "1.2.246.562.20.000003"
@@ -33,7 +32,7 @@
 
     (fixture/add-haku-mock "1.2.246.562.29.000001" :tila "julkaistu" :organisaatio mocks/Oppilaitos1)
 
-    (fixture/add-koulutus-mock koulutus-oid :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1)
+    (fixture/add-koulutus-mock koulutus-oid :tila "julkaistu" :nimi "Hauska koulutus" :organisaatio mocks/Oppilaitos1 :sorakuvausId sorakuvaus-id)
 
     (fixture/add-hakukohde-mock hakukohdeOid1 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId1)
     (fixture/add-hakukohde-mock hakukohdeOid2 toteutus-oid "1.2.246.562.29.000001" :tila "julkaistu" :esikatselu "false" :organisaatio mocks/Oppilaitos1 :valintaperuste valintaperusteId2)
@@ -45,7 +44,7 @@
     (fixture/add-valintaperuste-mock valintaperusteId3 :tila "tallennettu" :esikatselu "true")
 
     (fixture/add-toteutus-mock toteutus-oid koulutus-oid)
-    (fixture/add-koulutus-mock koulutus-oid)
+    (fixture/add-koulutus-mock koulutus-oid :sorakuvausId sorakuvaus-id)
     (fixture/add-haku-mock "1.2.246.562.29.000001")
     (fixture/add-sorakuvaus-mock sorakuvaus-id :tila "julkaistu")
 

--- a/test/konfo_backend/index/lokalisointi_test.clj
+++ b/test/konfo_backend/index/lokalisointi_test.clj
@@ -7,9 +7,9 @@
 
 (deftest lokalisointi-test
   (testing "Get lokalisointi"
-    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y] {:found true,
-                                                                            :_source {:lng y
-                                                                                      :tyyppi "lokalisointi"
-                                                                                      :translation {:moi "moi"}}})]
+    (with-redefs [clj-elasticsearch.elastic-connect/get-document (fn [x y & z] {:found   true,
+                                                                                :_source {:lng         y
+                                                                                          :tyyppi      "lokalisointi"
+                                                                                          :translation {:moi "moi"}}})]
       (let [response (get-ok "/konfo-backend/translation/fi")]
         (is (= response {:moi "moi"}))))))

--- a/test/konfo_backend/search/search_test_tools.clj
+++ b/test/konfo_backend/search/search_test_tools.clj
@@ -38,6 +38,12 @@
      :koulutusalaKoodiUrit ["kansallinenkoulutusluokitus2016koulutusalataso1_01#1",
                             "kansallinenkoulutusluokitus2016koulutusalataso1_02#1"]}))
 
+(defonce lukio-koulutus-metatieto
+         (cheshire/generate-string
+           {:tyyppi               "lk"
+            :koulutusalaKoodiUrit ["kansallinenkoulutusluokitus2016koulutusalataso1_01#1"]
+            :kuvauksenNimi        {:fi "kuvaus", :sv "kuvaus sv"}}))
+
 (defonce yo-koulutus-metatieto
   (cheshire/generate-string
     {:tyyppi               "yo"


### PR DESCRIPTION
- Uusien kenttien (lukiometadata, hakukohteen sorakuvaus ja koulutustyyppit) käsittely external-skeemaan. 
- hakukohteen uusien kenttien excludaus konfosta, koska ainakaan toistaiseksi näille kentille ei ole käyttöä
- indeksoijan versiota nostettu