### PR TITLE
Kto 1276

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
   :managed-dependencies [[org.flatland/ordered "1.5.7"]]
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [clj-time "0.15.0"]
+                 [org.clojure/core.memoize "1.0.236"]
                  ; Rest + server
                  [metosin/compojure-api "2.0.0-alpha31"]
                  [metosin/ring-swagger-ui "3.25.3"]

--- a/src/konfo_backend/koodisto/koodisto.clj
+++ b/src/konfo_backend/koodisto/koodisto.clj
@@ -1,7 +1,8 @@
 (ns konfo-backend.koodisto.koodisto
   (:require
     [konfo-backend.tools :refer [koodi-uri-no-version]]
-    [konfo-backend.elastic-tools :refer [get-source search]]))
+    [konfo-backend.elastic-tools :refer [get-source search]]
+    [clojure.core.memoize :as memo]))
 
 (defonce index-name "koodisto")
 
@@ -9,7 +10,10 @@
   [koodisto]
   (get-source index-name koodisto))
 
-(defn list-koodit
+(def get-koodisto-with-cache
+  (memo/ttl get-koodisto {} :ttl/threshold (* 1000 60 5))) ;5 minuutin cache
+
+(defn- list-koodit
   [koodisto]
   (vec (:koodit (get-koodisto koodisto))))
 

--- a/src/konfo_backend/koodisto/koodisto.clj
+++ b/src/konfo_backend/koodisto/koodisto.clj
@@ -6,7 +6,7 @@
 
 (defonce index-name "koodisto")
 
-(defn get-koodisto
+(defn- get-koodisto
   [koodisto]
   (get-source index-name koodisto))
 
@@ -15,7 +15,7 @@
 
 (defn- list-koodit
   [koodisto]
-  (vec (:koodit (get-koodisto koodisto))))
+  (vec (:koodit (get-koodisto-with-cache koodisto))))
 
 (defn list-koodi-urit
   [koodisto]

--- a/src/konfo_backend/search/filters.clj
+++ b/src/konfo_backend/search/filters.clj
@@ -18,7 +18,7 @@
 
 (defn- koodisto->filters
   [filter-counts koodisto]
-  (reduce-merge-map #(koodi->filter filter-counts %) (:koodit (k/get-koodisto koodisto))))
+  (reduce-merge-map #(koodi->filter filter-counts %) (:koodit (k/get-koodisto-with-cache koodisto))))
 
 (defn- beta-koulutustyyppi
   [filter-counts]

--- a/test/konfo_backend/external/external_search_api_test.clj
+++ b/test/konfo_backend/external/external_search_api_test.clj
@@ -47,7 +47,7 @@
 
   (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 koulutusOid3 koulutusOid4 koulutusOid5] :oppilaitokset [punkaharjun-yliopisto, helsingin-yliopisto]} orgs)
 
-  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto mock-get-koodisto]
+  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto-with-cache mock-get-koodisto]
     (testing "Search toteutukset"
       (let [r (search :keyword "hevonen" :koulutustyyppi "amm")]
         (is (= 2 (:total r)))

--- a/test/konfo_backend/search/koulutus_jarjestajat_search_test.clj
+++ b/test/konfo_backend/search/koulutus_jarjestajat_search_test.clj
@@ -47,7 +47,7 @@
 
   (fixture/index-oids-without-related-indices {:koulutukset [autoala-oid hevosala-oid] :oppilaitokset [punkaharjun-yliopisto, helsingin-yliopisto]} orgs)
 
-  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto mock-get-koodisto]
+  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto-with-cache mock-get-koodisto]
     (testing "Search koulutuksen järjestäjät with bad requests:"
       (testing "Invalid lng"
         (is (= "Virheellinen kieli") (->bad-request-body autoala-oid :lng "foo")))

--- a/test/konfo_backend/search/koulutus_search_test.clj
+++ b/test/konfo_backend/search/koulutus_search_test.clj
@@ -97,7 +97,7 @@
      :haut [haku-oid-1 haku-oid-2]
      } (fn [x & {:as params}] punkaharju-org))
 
-  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto mock-get-koodisto
+  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto-with-cache mock-get-koodisto
                 konfo-backend.index.eperuste/get-kuvaukset-by-eperuste-ids mock-get-kuvaukset]
     (testing "Search koulutukset with bad requests:"
       (testing "Invalid lng"

--- a/test/konfo_backend/search/oppilaitos_search_test.clj
+++ b/test/konfo_backend/search/oppilaitos_search_test.clj
@@ -45,7 +45,7 @@
 
   (fixture/index-oids-without-related-indices {:koulutukset [koulutusOid1 koulutusOid2 koulutusOid3 koulutusOid4] :oppilaitokset [punkaharjun-yliopisto helsingin-yliopisto]} orgs)
 
-  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto mock-get-koodisto]
+  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto-with-cache mock-get-koodisto]
     (testing "Search oppilaitokset with bad requests:"
       (testing "Invalid lng"
         (is (= "Virheellinen kieli")      (->bad-request-body :sijainti "kunta_618" :lng "foo")))

--- a/test/konfo_backend/search/oppilaitos_tarjonta_search_test.clj
+++ b/test/konfo_backend/search/oppilaitos_tarjonta_search_test.clj
@@ -40,7 +40,7 @@
 
   (fixture/index-oids-without-related-indices {:koulutukset [autoala-oid hevosala-oid] :oppilaitokset [punkaharjun-yliopisto, helsingin-yliopisto]} orgs)
 
-  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto mock-get-koodisto]
+  (with-redefs [konfo-backend.koodisto.koodisto/get-koodisto-with-cache mock-get-koodisto]
     (testing "Search oppilaitoksen tarjonta with bad requests:"
       (testing "Invalid lng"
         (is (= "Virheellinen kieli") (->bad-request-body punkaharjun-yliopisto :lng "foo")))


### PR DESCRIPTION
Lisätty 5 minuutin cachetus koodisto-indeksistä hakuun. Jokaiselle filtterille pitää erikseen kysyä koodistoarvot koodisto-indeksistä konfo-backendin koulutushakukyselyä luodessa ja siinä vaiheessa kun lasketaan lukumääriä koulutushaun vastauksesta. Molemmat tekevät 9 http-kutsua, joten yhteensä tuli 18 kutsua.