### PR TITLE
KTO-1408: TUVA koulutustyyppi-rajaimen hierarkia

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,6 +46,8 @@
   :target-path "target/%s"
   :plugins [[lein-environ "1.1.0"]
             [lein-auto "0.1.3"]
+            [lein-zprint "1.2.0"]
+            [lein-cljfmt "0.8.0"]
             [com.jakemccrary/lein-test-refresh "0.24.1"]]
   :main konfo-backend.core
   :profiles {:dev {:plugins [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
@@ -84,4 +86,5 @@
             "ci-test" ["with-profile" "+ci-test" "test"]
             "auto-test" ["with-profile" "+ci-test" "auto" "test"]
             "test-reload" ["with-profile" "+ci-test" "test-refresh"]
-            "cloverage" ["with-profile" "+test" "cloverage"]})
+            "cloverage" ["with-profile" "+test" "cloverage"]}
+  :zprint {:width 100 :old? false :style :community :map {:comma? false}})

--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,7 @@
                    :jvm-opts ["-Dport=3006"]}
              :updater {:jvm-opts ["-Dmode=updater" "-Dport=3006"]}
              :test {:dependencies [[ring/ring-mock "0.3.2"]
-                                   [kouta-indeksoija-service "9.1.0-SNAPSHOT"]
+                                   [kouta-indeksoija-service "9.2.0-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "6.20.1-SNAPSHOT"]
                                    [fi.oph.kouta/kouta-backend "6.20.1-SNAPSHOT" :classifier "tests"]
                                    [fi.oph.kouta/kouta-common "2.6.0-SNAPSHOT" :classifier "tests"]
@@ -67,7 +67,7 @@
                                      (intern 'clj-elasticsearch.elastic-utils 'elastic-host (str "http://127.0.0.1:" elasticPort)))
                                    (utils/global-docker-elastic-fixture))]}
              :ci-test {:dependencies [[ring/ring-mock "0.3.2"]
-                                      [kouta-indeksoija-service "9.1.0-SNAPSHOT"]
+                                      [kouta-indeksoija-service "9.2.0-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "6.20.1-SNAPSHOT"]
                                       [fi.oph.kouta/kouta-backend "6.20.1-SNAPSHOT" :classifier "tests"]
                                       [fi.oph.kouta/kouta-common "2.6.0-SNAPSHOT" :classifier "tests"]

--- a/src/konfo_backend/search/api.clj
+++ b/src/konfo_backend/search/api.clj
@@ -6,7 +6,7 @@
     [compojure.api.core :refer [GET context]]
     [ring.util.http-response :refer :all]
     [clj-log.access-log :refer [with-access-logging]]
-    [konfo-backend.tools :refer [comma-separated-string->vec amm-muu->alatyypit vapaa-sivistystyo->alatyypit]]))
+    [konfo-backend.tools :refer [comma-separated-string->vec]]))
 
 (def paths
   "|  /search/filters:
@@ -540,7 +540,7 @@
 
 
 (defn- parse-constraints [koulutustyyppi sijainti opetuskieli koulutusala opetustapa valintatapa hakukaynnissa hakutapa yhteishaku pohjakoulutusvaatimus]
-  {:koulutustyyppi        (->> koulutustyyppi (comma-separated-string->vec) (amm-muu->alatyypit) (vapaa-sivistystyo->alatyypit))
+  {:koulutustyyppi        (->> koulutustyyppi (comma-separated-string->vec))
    :sijainti              (comma-separated-string->vec sijainti)
    :opetuskieli           (comma-separated-string->vec opetuskieli)
    :koulutusala           (comma-separated-string->vec koulutusala)

--- a/src/konfo_backend/search/filters.clj
+++ b/src/konfo_backend/search/filters.clj
@@ -51,20 +51,36 @@
         amm-tutkinnon-osa-count (get filter-counts :amm-tutkinnon-osa 0)
         telma-count (get filter-counts :telma 0)
         amm-muu-count (+ amm-osaamisala-count amm-tutkinnon-osa-count telma-count)
-        tuva-count (get filter-counts :tuva 0)
+        tuva-normal-count (get filter-counts :tuva-normal 0)
+        tuva-erityisopetus-count (get filter-counts :tuva-erityisopetus 0)
+        total-tuva-count (+ tuva-normal-count tuva-erityisopetus-count)
         vapaa-sivistystyo-opistovuosi-count (get filter-counts :vapaa-sivistystyo-opistovuosi 0)
         vapaa-sivistystyo-muu-count (get filter-counts :vapaa-sivistystyo-muu 0)
         total-vapaa-sivistystyo-count (+ vapaa-sivistystyo-opistovuosi-count vapaa-sivistystyo-muu-count)
         ]
-    {:amm-muu (cond-> {:count amm-muu-count
+    {:amm-muu (cond-> {
                        :alakoodit {
-                         :amm-tutkinnon-osa {:count amm-tutkinnon-osa-count},
+                         :amm-tutkinnon-osa {:count amm-tutkinnon-osa-count}
                          :amm-osaamisala {:count amm-osaamisala-count}
-                         :telma {:count telma-count}}})
-     :tuva {:count tuva-count}
-     :vapaa-sivistystyo (cond-> {:count total-vapaa-sivistystyo-count
-                                 :alakoodit {:vapaa-sivistystyo-opistovuosi {:count vapaa-sivistystyo-opistovuosi-count}
-                                             :vapaa-sivistystyo-muu {:count vapaa-sivistystyo-muu-count}}})}))
+                         :telma {:count telma-count}
+                                   }
+                       }
+                      amm-muu-count (assoc :count amm-muu-count))
+     :tuva (cond-> {
+            :alakoodit {
+                        :tuva-normal {:count tuva-normal-count}
+                        :tuva-erityisopetus {:count tuva-erityisopetus-count}
+                        }
+            }
+            total-tuva-count (assoc :count total-tuva-count))
+     :vapaa-sivistystyo (cond-> {
+                                 :alakoodit {
+                                             :vapaa-sivistystyo-opistovuosi {:count vapaa-sivistystyo-opistovuosi-count}
+                                             :vapaa-sivistystyo-muu {:count vapaa-sivistystyo-muu-count}
+                                             }
+                                 }
+                                total-vapaa-sivistystyo-count (assoc :count total-vapaa-sivistystyo-count))}))
+
 
 (defn- hakukaynnissa
   [aggs]

--- a/src/konfo_backend/search/filters.clj
+++ b/src/konfo_backend/search/filters.clj
@@ -1,24 +1,23 @@
 (ns konfo-backend.search.filters
-  (:require
-    [konfo-backend.koodisto.koodisto :as k]
-    [konfo-backend.index.haku :refer [get-yhteishaut]]
-    [konfo-backend.tools :refer [reduce-merge-map]]))
+  (:require [konfo-backend.koodisto.koodisto :as k]
+            [konfo-backend.index.haku :refer [get-yhteishaut]]
+            [konfo-backend.tools :refer [reduce-merge-map]]))
 
 (defn- koodi->filter
   [filter-counts koodi]
-  (let [koodiUri  (keyword (:koodiUri koodi))
-        nimi      (get-in koodi [:nimi])
-        count     (koodiUri filter-counts)
+  (let [koodiUri (keyword (:koodiUri koodi))
+        nimi (get-in koodi [:nimi])
+        count (koodiUri filter-counts)
         alakoodit (when (contains? koodi :alakoodit)
                     (reduce-merge-map #(koodi->filter filter-counts %) (:alakoodit koodi)))]
-
-    {koodiUri (cond->     {:nimi nimi}
-                count     (assoc :count count)
+    {koodiUri (cond-> {:nimi nimi}
+                count (assoc :count count)
                 alakoodit (assoc :alakoodit alakoodit))}))
 
 (defn- koodisto->filters
   [filter-counts koodisto]
-  (reduce-merge-map #(koodi->filter filter-counts %) (:koodit (k/get-koodisto-with-cache koodisto))))
+  (reduce-merge-map #(koodi->filter filter-counts %)
+                    (:koodit (k/get-koodisto-with-cache koodisto))))
 
 (defn- beta-koulutustyyppi
   [filter-counts]
@@ -33,17 +32,19 @@
         kandi-ja-maisteri-count (get filter-counts :kandi-ja-maisteri 0)
         maisteri-count (get filter-counts :maisteri 0)
         tohtori-count (get filter-counts :tohtori 0)]
-    {:lk  {:count lukio-count}
-     :amm (cond-> {:alakoodit (select-keys koulutustyyppi-info-and-counts [:koulutustyyppi_26 :koulutustyyppi_4 :koulutustyyppi_11 :koulutustyyppi_12])}
-                  ammatillinen-count (assoc :count ammatillinen-count))
+    {:lk {:count lukio-count}
+     :amm (cond-> {:alakoodit (select-keys koulutustyyppi-info-and-counts
+                                           [:koulutustyyppi_26 :koulutustyyppi_4 :koulutustyyppi_11
+                                            :koulutustyyppi_12])}
+            ammatillinen-count (assoc :count ammatillinen-count))
      :amk (cond-> {:alakoodit {:amk-alempi {:count amk-alempi-count}
                                :amk-ylempi {:count amk-ylempi-count}}}
-                  amk-count (assoc :count amk-count))
-     :yo  (cond-> {:alakoodit {:kandi             {:count kandi-count}
-                               :kandi-ja-maisteri {:count kandi-ja-maisteri-count}
-                               :maisteri          {:count maisteri-count}
-                               :tohtori           {:count tohtori-count}}}
-                  yo-count (assoc :count yo-count))}))
+            amk-count (assoc :count amk-count))
+     :yo (cond-> {:alakoodit {:kandi {:count kandi-count}
+                              :kandi-ja-maisteri {:count kandi-ja-maisteri-count}
+                              :maisteri {:count maisteri-count}
+                              :tohtori {:count tohtori-count}}}
+           yo-count (assoc :count yo-count))}))
 
 (defn- beta-koulutustyyppi-muu
   [filter-counts]
@@ -56,88 +57,72 @@
         total-tuva-count (get filter-counts :tuva 0)
         vapaa-sivistystyo-opistovuosi-count (get filter-counts :vapaa-sivistystyo-opistovuosi 0)
         vapaa-sivistystyo-muu-count (get filter-counts :vapaa-sivistystyo-muu 0)
-        total-vapaa-sivistystyo-count (+ vapaa-sivistystyo-opistovuosi-count vapaa-sivistystyo-muu-count)
-        ]
-    {:amm-muu (cond-> {
-                       :alakoodit {
-                         :amm-tutkinnon-osa {:count amm-tutkinnon-osa-count}
-                         :amm-osaamisala {:count amm-osaamisala-count}
-                         :telma {:count telma-count}
-                                   }
-                       }
-                      amm-muu-count (assoc :count amm-muu-count))
-     :tuva (cond-> {
-            :alakoodit {
-                        :tuva-normal {:count tuva-normal-count}
-                        :tuva-erityisopetus {:count tuva-erityisopetus-count}
-                        }
-            }
-            total-tuva-count (assoc :count total-tuva-count))
-     :vapaa-sivistystyo (cond-> {
-                                 :alakoodit {
-                                             :vapaa-sivistystyo-opistovuosi {:count vapaa-sivistystyo-opistovuosi-count}
-                                             :vapaa-sivistystyo-muu {:count vapaa-sivistystyo-muu-count}
-                                             }
-                                 }
-                                total-vapaa-sivistystyo-count (assoc :count total-vapaa-sivistystyo-count))}))
+        total-vapaa-sivistystyo-count (+ vapaa-sivistystyo-opistovuosi-count
+                                         vapaa-sivistystyo-muu-count)]
+    {:amm-muu (cond-> {:alakoodit {:amm-tutkinnon-osa {:count amm-tutkinnon-osa-count}
+                                   :amm-osaamisala {:count amm-osaamisala-count}
+                                   :telma {:count telma-count}}}
+                amm-muu-count (assoc :count amm-muu-count))
+     :tuva (cond-> {:alakoodit {:tuva-normal {:count tuva-normal-count}
+                                :tuva-erityisopetus {:count tuva-erityisopetus-count}}}
+             total-tuva-count (assoc :count total-tuva-count))
+     :vapaa-sivistystyo
+     (cond-> {:alakoodit {:vapaa-sivistystyo-opistovuosi {:count
+                                                          vapaa-sivistystyo-opistovuosi-count}
+                          :vapaa-sivistystyo-muu {:count vapaa-sivistystyo-muu-count}}}
+       total-vapaa-sivistystyo-count (assoc :count total-vapaa-sivistystyo-count))}))
 
-
-(defn- hakukaynnissa
-  [aggs]
-  {:count (:hakukaynnissa aggs) })
+(defn- hakukaynnissa [aggs] {:count (:hakukaynnissa aggs)})
 
 (defn- yhteishaku
   [aggs]
   (let [yhteishaut (get-yhteishaut)]
-    (reduce
-      (fn [ret-val yhteishaku]
-        (let [yhteishakuKey (keyword (:oid yhteishaku))]
-          (assoc ret-val yhteishakuKey (-> yhteishaku
-                                           (dissoc :oid)
-                                           (assoc :count (yhteishakuKey aggs))))))
-      {}
-      yhteishaut)))
+    (reduce (fn [ret-val yhteishaku]
+              (let [yhteishakuKey (keyword (:oid yhteishaku))]
+                (assoc ret-val
+                       yhteishakuKey
+                       (-> yhteishaku
+                           (dissoc :oid)
+                           (assoc :count (yhteishakuKey aggs))))))
+            {}
+            yhteishaut)))
 
 (defn generate-filter-counts
   ([filter-counts]
    (let [filters (partial koodisto->filters filter-counts)]
-     {:opetuskieli           (filters "oppilaitoksenopetuskieli")
-      :maakunta              (filters "maakunta")
-      :kunta                 (filters "kunta")
-      :koulutustyyppi        (beta-koulutustyyppi filter-counts)
-      :koulutustyyppi-muu    (beta-koulutustyyppi-muu filter-counts)
-      :koulutusala           (filters "kansallinenkoulutusluokitus2016koulutusalataso1")
-      :opetustapa            (filters "opetuspaikkakk")
-      :valintatapa           (filters "valintatapajono")
-      :hakukaynnissa         (hakukaynnissa filter-counts)
-      :hakutapa              (filters "hakutapa")
-      :yhteishaku            (yhteishaku filter-counts)
+     {:opetuskieli (filters "oppilaitoksenopetuskieli")
+      :maakunta (filters "maakunta")
+      :kunta (filters "kunta")
+      :koulutustyyppi (beta-koulutustyyppi filter-counts)
+      :koulutustyyppi-muu (beta-koulutustyyppi-muu filter-counts)
+      :koulutusala (filters "kansallinenkoulutusluokitus2016koulutusalataso1")
+      :opetustapa (filters "opetuspaikkakk")
+      :valintatapa (filters "valintatapajono")
+      :hakukaynnissa (hakukaynnissa filter-counts)
+      :hakutapa (filters "hakutapa")
+      :yhteishaku (yhteishaku filter-counts)
       :pohjakoulutusvaatimus (filters "pohjakoulutusvaatimuskonfo")}))
-  ([]
-   (generate-filter-counts {})))
+  ([] (generate-filter-counts {})))
 
 (defn generate-filter-counts-for-jarjestajat
   [filter-counts]
   (let [filters (partial koodisto->filters filter-counts)]
-    {:opetuskieli           (filters "oppilaitoksenopetuskieli")
-     :maakunta              (filters "maakunta")
-     :kunta                 (filters "kunta")
-     :opetustapa            (filters "opetuspaikkakk")
-     :valintatapa           (filters "valintatapajono")
-     :hakukaynnissa         (hakukaynnissa filter-counts)
-     :hakutapa              (filters "hakutapa")
-     :yhteishaku            (yhteishaku filter-counts)
+    {:opetuskieli (filters "oppilaitoksenopetuskieli")
+     :maakunta (filters "maakunta")
+     :kunta (filters "kunta")
+     :opetustapa (filters "opetuspaikkakk")
+     :valintatapa (filters "valintatapajono")
+     :hakukaynnissa (hakukaynnissa filter-counts)
+     :hakutapa (filters "hakutapa")
+     :yhteishaku (yhteishaku filter-counts)
      :pohjakoulutusvaatimus (filters "pohjakoulutusvaatimuskonfo")}))
 
+(defn- filter->obj [suodatin koodi nimi] {:suodatin suodatin :koodi koodi :nimi nimi})
 
-(defn- filter->obj [suodatin koodi nimi]
-  {:suodatin suodatin
-   :koodi koodi
-   :nimi nimi})
-
-(defn flattened-filter-counts []
+(defn flattened-filter-counts
+  []
   (if-let [result (generate-filter-counts)]
     (reduce-kv (fn [r suodatin m]
-                   (concat r (into []
-                                   (for [[k v] m] (filter->obj suodatin k (:nimi v)))))
-                   ) [] result)))
+                 (concat r (into [] (for [[k v] m] (filter->obj suodatin k (:nimi v))))))
+               []
+               result)))

--- a/src/konfo_backend/search/filters.clj
+++ b/src/konfo_backend/search/filters.clj
@@ -53,7 +53,7 @@
         amm-muu-count (+ amm-osaamisala-count amm-tutkinnon-osa-count telma-count)
         tuva-normal-count (get filter-counts :tuva-normal 0)
         tuva-erityisopetus-count (get filter-counts :tuva-erityisopetus 0)
-        total-tuva-count (+ tuva-normal-count tuva-erityisopetus-count)
+        total-tuva-count (get filter-counts :tuva 0)
         vapaa-sivistystyo-opistovuosi-count (get filter-counts :vapaa-sivistystyo-opistovuosi 0)
         vapaa-sivistystyo-muu-count (get filter-counts :vapaa-sivistystyo-muu 0)
         total-vapaa-sivistystyo-count (+ vapaa-sivistystyo-opistovuosi-count vapaa-sivistystyo-muu-count)

--- a/src/konfo_backend/search/query.clj
+++ b/src/konfo_backend/search/query.clj
@@ -194,7 +194,7 @@
 
 (defn- koulutustyyppi-filters
   [field]
-  (->filters-aggregation field '["amm", "amm-muu", "amm-tutkinnon-osa" "amm-osaamisala" "lk" "amk" "yo" "amk-alempi" "amk-ylempi" "kandi" "kandi-ja-maisteri" "maisteri" "tohtori" "tuva-normal" "tuva-erityisopetus" "tuva" "tuva-normal" "tuva-erityisopetus" "telma", "vapaa-sivistystyo", "vapaa-sivistystyo-opistovuosi", "vapaa-sivistystyo-muu"]))
+  (->filters-aggregation field '["amm", "amm-muu", "amm-tutkinnon-osa" "amm-osaamisala" "lk" "amk" "yo" "amk-alempi" "amk-ylempi" "kandi" "kandi-ja-maisteri" "maisteri" "tohtori" "tuva" "tuva-normal" "tuva-erityisopetus" "telma", "vapaa-sivistystyo", "vapaa-sivistystyo-opistovuosi", "vapaa-sivistystyo-muu"]))
 
 (defn- koulutustyyppi-filters-for-subentity
   [field]

--- a/src/konfo_backend/search/query.clj
+++ b/src/konfo_backend/search/query.clj
@@ -194,7 +194,7 @@
 
 (defn- koulutustyyppi-filters
   [field]
-  (->filters-aggregation field '["amm" "amm-tutkinnon-osa" "amm-osaamisala" "lk" "amk" "yo" "amk-alempi" "amk-ylempi" "kandi" "kandi-ja-maisteri" "maisteri" "tohtori" "tuva" "telma", "vapaa-sivistystyo-opistovuosi", "vapaa-sivistystyo-muu"]))
+  (->filters-aggregation field '["amm", "amm-tutkinnon-osa" "amm-osaamisala" "lk" "amk" "yo" "amk-alempi" "amk-ylempi" "kandi" "kandi-ja-maisteri" "maisteri" "tohtori" "tuva" "tuva-normal" "tuva-erityisopetus" "telma", "vapaa-sivistystyo-opistovuosi", "vapaa-sivistystyo-muu"]))
 
 (defn- koulutustyyppi-filters-for-subentity
   [field]

--- a/src/konfo_backend/search/query.clj
+++ b/src/konfo_backend/search/query.clj
@@ -194,7 +194,7 @@
 
 (defn- koulutustyyppi-filters
   [field]
-  (->filters-aggregation field '["amm", "amm-tutkinnon-osa" "amm-osaamisala" "lk" "amk" "yo" "amk-alempi" "amk-ylempi" "kandi" "kandi-ja-maisteri" "maisteri" "tohtori" "tuva" "tuva-normal" "tuva-erityisopetus" "telma", "vapaa-sivistystyo-opistovuosi", "vapaa-sivistystyo-muu"]))
+  (->filters-aggregation field '["amm", "amm-muu", "amm-tutkinnon-osa" "amm-osaamisala" "lk" "amk" "yo" "amk-alempi" "amk-ylempi" "kandi" "kandi-ja-maisteri" "maisteri" "tohtori" "tuva-normal" "tuva-erityisopetus" "tuva" "tuva-normal" "tuva-erityisopetus" "telma", "vapaa-sivistystyo", "vapaa-sivistystyo-opistovuosi", "vapaa-sivistystyo-muu"]))
 
 (defn- koulutustyyppi-filters-for-subentity
   [field]

--- a/src/konfo_backend/tools.clj
+++ b/src/konfo_backend/tools.clj
@@ -115,19 +115,6 @@
   [coll e]
   (remove #(= e %) coll))
 
-;TODO Tämä mäppäily pitäisi tehdä indeksoijassa (laitetaan koulutustyypiksi hakuindeksiin myös amm-muu kyseisille koulutuksille)
-(defn amm-muu->alatyypit
-  [coll]
-  (if (contains-element? coll "amm-muu")
-    (-> coll (remove-element "amm-muu") (conj "amm-tutkinnon-osa" "amm-osaamisala"))
-    coll))
-
-(defn vapaa-sivistystyo->alatyypit
-  [coll]
-  (if (contains-element? coll "vapaa-sivistystyo")
-    (-> coll (remove-element "vapaa-sivistystyo") (conj "vapaa-sivistystyo-opistovuosi" "vapaa-sivistystyo-muu"))
-    coll))
-
 (defn ->koodi-with-version-wildcard
   [koodi]
   (str koodi "#*"))

--- a/test/konfo_backend/search/query_test.clj
+++ b/test/konfo_backend/search/query_test.clj
@@ -60,10 +60,12 @@
                                                                                                      :kandi-ja-maisteri {:term {:search_terms.koulutustyypit.keyword "kandi-ja-maisteri"}}
                                                                                                      :yo {:term {:search_terms.koulutustyypit.keyword "yo"}}
                                                                                                      :amm {:term {:search_terms.koulutustyypit.keyword "amm"}}
+                                                                                                     :amm-muu {:term {:search_terms.koulutustyypit.keyword "amm-muu"}}
                                                                                                      :tuva {:term {:search_terms.koulutustyypit.keyword "tuva"}}
                                                                                                      :tuva-normal {:term {:search_terms.koulutustyypit.keyword "tuva-normal"}}
                                                                                                      :tuva-erityisopetus {:term {:search_terms.koulutustyypit.keyword "tuva-erityisopetus"}}
                                                                                                      :telma {:term {:search_terms.koulutustyypit.keyword "telma"}}
+                                                                                                     :vapaa-sivistystyo {:term {:search_terms.koulutustyypit.keyword "vapaa-sivistystyo"}}
                                                                                                      :vapaa-sivistystyo-opistovuosi {:term {:search_terms.koulutustyypit.keyword "vapaa-sivistystyo-opistovuosi"}}
                                                                                                      :vapaa-sivistystyo-muu {:term {:search_terms.koulutustyypit.keyword "vapaa-sivistystyo-muu"}}
                                                                                                      }}, :aggs {:real_hits {:reverse_nested {}}}}}}})))))

--- a/test/konfo_backend/search/query_test.clj
+++ b/test/konfo_backend/search/query_test.clj
@@ -61,6 +61,8 @@
                                                                                                      :yo {:term {:search_terms.koulutustyypit.keyword "yo"}}
                                                                                                      :amm {:term {:search_terms.koulutustyypit.keyword "amm"}}
                                                                                                      :tuva {:term {:search_terms.koulutustyypit.keyword "tuva"}}
+                                                                                                     :tuva-normal {:term {:search_terms.koulutustyypit.keyword "tuva-normal"}}
+                                                                                                     :tuva-erityisopetus {:term {:search_terms.koulutustyypit.keyword "tuva-erityisopetus"}}
                                                                                                      :telma {:term {:search_terms.koulutustyypit.keyword "telma"}}
                                                                                                      :vapaa-sivistystyo-opistovuosi {:term {:search_terms.koulutustyypit.keyword "vapaa-sivistystyo-opistovuosi"}}
                                                                                                      :vapaa-sivistystyo-muu {:term {:search_terms.koulutustyypit.keyword "vapaa-sivistystyo-muu"}}


### PR DESCRIPTION
Lisäksi siirretty muidenkin ylätason koulutustyyppien ("amm-muu", "vapaa-sivistystyo") muodostaminen indeksoijaan.