### PR TITLE
OK-376: Suosikkien vertailu

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,8 @@
                  ; Rest + server
                  [metosin/compojure-api "2.0.0-alpha31"]
                  [metosin/ring-swagger-ui "4.18.1"]
+                 [metosin/schema-tools "0.13.1"]
+                 [clj-commons/clj-yaml "1.0.27"]
                  [clj-http "3.12.3"]
                  [com.amazonaws/aws-java-sdk-s3 "1.12.550"]
                  [com.amazonaws/aws-java-sdk-sqs "1.12.550"]

--- a/src/konfo_backend/core.clj
+++ b/src/konfo_backend/core.clj
@@ -96,7 +96,8 @@
               |  schemas:
               "
               default/schemas "\n"
-              external/schemas
+              external/schemas "\n"
+              suosikit/schemas
               ))))
 
       (GET "/redoc/index.html" request

--- a/src/konfo_backend/external/schema/koodi.clj
+++ b/src/konfo_backend/external/schema/koodi.clj
@@ -370,6 +370,8 @@
 
 (def LukioDiplomiKoodi s/Str)
 
+(def KieliKoodiPattern #"^kieli_")
+
 (def schemas
   (str
     kunta-schema "\n"

--- a/src/konfo_backend/external/schema/koulutus.clj
+++ b/src/konfo_backend/external/schema/koulutus.clj
@@ -84,7 +84,7 @@
   {:oid                          KoulutusOid
    (s/->OptionalKey :externalId) s/Str
    :johtaaTutkintoon             s/Bool
-   :koulutustyyppi               Koulutustyyppi
+   :koulutustyyppi               KoutaKoulutustyyppi
    :koulutukset                  [(->Koodi KoulutusKoodi)]
    :tila                         Julkaistu
    :tarjoajat                    [Organisaatio]

--- a/src/konfo_backend/external/schema/koulutus_metadata.clj
+++ b/src/konfo_backend/external/schema/koulutus_metadata.clj
@@ -2,8 +2,7 @@
   (:require
     [schema.core :as s]
     [konfo-backend.external.schema.common :refer :all :exclude [schemas]]
-    [konfo-backend.external.schema.koodi :refer :all :exclude [schemas]]
-    [schema-tools.core :as st]))
+    [konfo-backend.external.schema.koodi :refer :all :exclude [schemas]]))
 
 (def schemas
    "|    Eperuste:
@@ -92,6 +91,6 @@
     (s/->OptionalKey :opintojenLaajuusNumeroMax)  (s/maybe s/Num)
     (s/->OptionalKey :opintojenLaajuusyksikko)    (->Koodi OpintojenLaajuusyksikkoKoodi)
     (s/->OptionalKey :tutkintonimike)             [(s/maybe (->Koodi TutkintonimikeKoodi))]
-    :tyyppi                                       Koulutustyyppi
+    :tyyppi                                       KoutaKoulutustyyppi
     s/Any                                         s/Any
     })

--- a/src/konfo_backend/external/schema/search.clj
+++ b/src/konfo_backend/external/schema/search.clj
@@ -1,7 +1,6 @@
 (ns konfo-backend.external.schema.search
   (:require
     [schema.core :as s]
-    [schema-tools.core :as st]
     [konfo-backend.external.schema.common :refer :all :exclude [schemas]]
     [konfo-backend.external.schema.koodi :refer :all :exclude [schemas]]))
 
@@ -74,7 +73,7 @@
   {:oid                                       KoulutusOid
    :nimi                                      Kielistetty
    :kielivalinta                              [Kieli]
-   :koulutustyyppi                            Koulutustyyppi
+   :koulutustyyppi                            KoutaKoulutustyyppi
    :koulutukset                               [(->Koodi KoulutusKoodi)]
    :kuvaus                                    (s/maybe Kielistetty)
    (s/->OptionalKey :ePerusteId)              (s/maybe s/Int)

--- a/src/konfo_backend/external/schema/sorakuvaus.clj
+++ b/src/konfo_backend/external/schema/sorakuvaus.clj
@@ -66,7 +66,7 @@
 (def Sorakuvaus
   {:id s/Str
    (s/->OptionalKey :externalId) s/Str
-   :koulutustyyppi Koulutustyyppi
+   :koulutustyyppi KoutaKoulutustyyppi
    :tila Julkaistu
    :kielivalinta [Kieli]
    :nimi Kielistetty

--- a/src/konfo_backend/external/schema/toteutus_metadata.clj
+++ b/src/konfo_backend/external/schema/toteutus_metadata.clj
@@ -222,8 +222,7 @@
    :linkinAltTeksti   Kielistetty
    :sisallot          [Kielistetty]
    :tavoitteetKohde   Kielistetty
-   :tavoitteet        [Kielistetty]}
-)
+   :tavoitteet        [Kielistetty]})
 
 (def lukio-toteutus-metadata-schema
   "|    LukioToteutusMetadata:
@@ -262,10 +261,10 @@
    |          description: Osaamisalan linkin otsikko eri kielillä
    |          $ref: '#/components/schemas/Teksti'")
 
-(def AmmOsaamisala
-  {:koodi   (->Koodi #"osaamisala_\d+(#\d{1,2})?$")
-   :linkki  Kielistetty
-   :otsikko Kielistetty})
+(s/defschema AmmOsaamisala
+  {:koodi   (st/schema (->Koodi #"osaamisala_\d+(#\d{1,2})?$"))
+   :linkki  (st/schema Kielistetty {:description "Osaamisalan linkki ePerusteisiin"})
+   :otsikko (st/schema Kielistetty {:description "Osaamisalan linkin otsikko eri kielillä"})})
 
 (def amm-toteutus-metadata-schema
   "|    AmmatillinenToteutusMetadata:

--- a/src/konfo_backend/external/schema/valintaperustekuvaus.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus.clj
@@ -78,7 +78,7 @@
   {:id                                    s/Str
    (s/->OptionalKey :externalId)          s/Str
    :tila                                  Julkaistu
-   :koulutustyyppi                        Koulutustyyppi
+   :koulutustyyppi                        KoutaKoulutustyyppi
    :hakutapa                              (->Koodi HakutapaKoodi)
    :kohdejoukko                           (->Koodi HaunKohdejoukkoKoodi)
    (s/->OptionalKey :kohdejoukonTarkenne) (->Koodi HaunKohdejoukonTarkenneKoodi)

--- a/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
+++ b/src/konfo_backend/external/schema/valintaperustekuvaus_metadata.clj
@@ -170,7 +170,7 @@
    (s/->OptionalKey :vahimmaispisteet)     (s/maybe s/Num)})
 
 (def ValintaperusteKuvausMetadata
-  {:tyyppi         Koulutustyyppi
+  {:tyyppi         KoutaKoulutustyyppi
    (s/->OptionalKey :valintatavat)               [Valintatapa]
    (s/->OptionalKey :hakukelpoisuus)             Kielistetty
    (s/->OptionalKey :lisatiedot)                 Kielistetty

--- a/src/konfo_backend/suosikit/api.clj
+++ b/src/konfo_backend/suosikit/api.clj
@@ -1,66 +1,105 @@
 (ns konfo-backend.suosikit.api
-  (:require
-   [konfo-backend.suosikit.suosikit :as suosikit]
-   [compojure.api.core :as c]
-   [ring.util.http-response :refer [ok not-found]]
-   [clj-log.access-log :refer [with-access-logging]]
-   [konfo-backend.tools :refer [comma-separated-string->vec]]))
+  (:require [clj-log.access-log :refer [with-access-logging]]
+            [clojure.string :as string]
+            [compojure.api.core :as c]
+            [konfo-backend.external.schema.common :refer [->Koodi
+                                                          create-kielistetty-schema
+                                                          Kielistetty Kielivalikoima KoutaKoulutustyyppi Kuvaus Nimi Organisaatio
+                                                          schema-to-swagger-yaml spec-paths-to-swagger-yaml]]
+            [konfo-backend.external.schema.toteutus-metadata :refer [AmmOsaamisala
+                                                                     LukiodiplomiTieto]]
+            [konfo-backend.external.schema.valintakoe :refer [Valintakoe]]
+            [konfo-backend.suosikit.suosikit :as suosikit]
+            [konfo-backend.tools :refer [comma-separated-string->vec]]
+            [ring.util.http-response :refer [not-found ok]]
+            [schema-tools.core :as st]
+            [schema-tools.openapi.core :as openapi]
+            [schema.core :as s]))
 
-(def paths
-  "|  /suosikit:
-   |    get:
-   |      tags:
-   |        - internal
-   |      summary: Hae suosikeille tietoja
-   |      description: Hae annetuilla hakukohde-oideilla tietoja suosikit-listausta varten
-   |        Huom.! Vain Opintopolun sisäiseen käyttöön
-   |      parameters:
-   |        - in: query
-   |          name: hakukohde-oids
-   |          style: form
-   |          explode: false
-   |          schema:
-   |            type: array
-   |            items:
-   |              type: string
-   |          required: true
-   |          description: Pilkulla erotettu lista hakukohteiden oideja
-   |      responses:
-   |        '200':
-   |          description: Ok
-   |          content:
-   |            application/json:
-   |              schema:
-   |                type: json
-   |        '404':
-   |          description: Not found
-   |  /suosikit-vertailu:
-   |    get:
-   |      tags:
-   |        - internal
-   |      summary: Hae hakukohteille vertailutietoja
-   |      description: Hae annetuilla hakukohde-oideilla tietoja suosikkien vertailua varten
-   |        Huom.! Vain Opintopolun sisäiseen käyttöön
-   |      parameters:
-   |        - in: query
-   |          name: hakukohde-oids
-   |          style: form
-   |          explode: false
-   |          schema:
-   |            type: array
-   |            items:
-   |              type: string
-   |          required: true
-   |          description: Pilkulla erotettu lista hakukohteiden oideja
-   |      responses:
-   |        '200':
-   |          description: Ok
-   |          content:
-   |            application/json:
-   |              schema:
-   |                type: json
-   |        '404':
-   |          description: Not found")
+(s/defschema HakutietoHakuaika
+  {:alkaa s/Str
+   (s/optional-key :paattyy) s/Str
+   :formatoituAlkaa Kielistetty
+   (s/optional-key :formatoituPaattyy) Kielistetty
+   :hakuAuki Boolean
+   :hakuMennyt Boolean})
+
+(s/defschema SuosikitItem
+  {:nimi (st/schema Nimi {:description "Hakukohteen nimi eri kielillä"})
+   :hakukohdeOid (st/schema s/Str {:description "Hakukohteen yksilöivä tunniste"})
+   :toteutusOid (st/schema s/Str {:description "Hakukohteeseen liitetyn toteutuksen yksilöivä tunniste"
+                                  :example "1.2.246.562.17.00000000000000000009"})
+   :logo (st/schema s/Str {:description "Hakukohteen järjestyspaikan oppilaitoksen logon URL"})
+   :esittely (st/schema Kuvaus {:description "Hakukohteen järjestyspaikan oppilaitoksen esittely eri kielillä"})
+   (s/optional-key :tutkintonimikkeet) (st/schema [(->Koodi s/Str)] {:description "Lista tutkintonimikkeitä käännöksineen (tutkintonimikkeet-koodisto)"})
+   :jarjestyspaikka (st/schema Organisaatio {:description "Hakukohteen järjestyspaikan tiedot"})
+   :jarjestaaUrheilijanAmmKoulutusta s/Bool
+   :hakuajat [HakutietoHakuaika]})
+
+(s/defschema Pistetieto
+  {:tarjoaja s/Str
+   :hakukohdekoodi s/Str
+   :pisteet s/Num
+   :vuosi s/Str
+   :valintatapajonoOid s/Str
+   :hakukohdeOid s/Str
+   :hakuOid s/Str
+   :valintatapajonoTyyppi s/Str})
+
+(s/defschema KayntiOsoite (st/schema (create-kielistetty-schema "osoite")))
+(s/defschema SuosikitVertailuItem
+  (st/schema {:koulutustyyppi KoutaKoulutustyyppi
+              :nimi (st/schema Nimi {:description "Hakukohteen nimi eri kielillä"})
+              :hakukohdeOid (st/schema s/Str {:description "Hakukohteen yksilöivä tunniste"})
+              :toteutusOid (st/schema s/Str {:description "Hakukohteeseen liitetyn toteutuksen yksilöivä tunniste"
+                                             :example "1.2.246.562.17.00000000000000000009"})
+              :logo (st/schema s/Str {:description "Hakukohteen järjestyspaikan oppilaitoksen logon URL"})
+              :esittely (st/schema Kuvaus {:description "Hakukohteen järjestyspaikan oppilaitoksen esittely eri kielillä"})
+              :osoite (st/schema KayntiOsoite {:description "Hakukohteen järjestyspaikan käyntiosoite"})
+              (s/optional-key :opiskelijoita) (st/schema s/Int {:description "Hakukohteen järjestyspaikan oppilaitoksen opiskelijoiden määrä"})
+              (s/optional-key :osaamisalat) (st/schema [AmmOsaamisala] {:description "Lista ammatillisen koulutuksen osaamisalojen kuvauksia"})
+              :edellinenHaku (st/schema Pistetieto {:description "Edellisen haun tiedot"})
+              :valintakokeet (st/schema [Valintakoe] {:description "Hakukohteeseen liittyvät valintakokeet"})
+              :toinenAsteOnkoKaksoistutkinto (st/schema s/Bool {:description "Onko hakukohteen toisen asteen koulutuksessa mahdollista suorittaa kaksoistutkinto?"})
+              (s/->OptionalKey :lukiodiplomit) (st/schema [LukiodiplomiTieto])
+              :kielivalikoima (st/schema Kielivalikoima)
+              :jarjestaaUrheilijanAmmKoulutusta s/Bool}))
+
+(def schemas (string/join "\n" (map schema-to-swagger-yaml [SuosikitItem SuosikitVertailuItem])))
+
+(def suosikit-paths-spec
+  (openapi/openapi-spec
+   {:paths
+    {"/suosikit"
+     {:get {:tags ["internal"]
+            :summary "Hae suosikeille tietoja"
+            :description "Hae annetuilla hakukohde-oideilla tietoja suosikit-listausta varten. Huom.! Vain Opintopolun sisäiseen käyttöön"
+            :parameters [{:in "query"
+                          :name "hakukohde-oids"
+                          :style "form"
+                          :explode false
+                          :description "Pilkulla erotettu lista hakukohteiden oideja"
+                          :schema {:type "array"
+                                   :items {:type "string"}}}]
+            :responses {200 {:description "Ok"
+                             ::openapi/content {"application/json" (st/schema [SuosikitItem])}}
+                        404 {:description "Not found"}}}}
+     "/suosikit-vertailu"
+     {:get {:tags ["internal"]
+            :summary "Hae hakukohteille vertailutietoja"
+            :description "Hae annetuilla hakukohde-oideilla tietoja suosikkien vertailua varten. Huom.! Vain Opintopolun sisäiseen käyttöön"
+            :parameters [{:in "query"
+                          :name "hakukohde-oids"
+                          :style "form"
+                          :explode false
+                          :description "Pilkulla erotettu lista hakukohteiden oideja"
+                          :schema {:type "array"
+                                   :items {:type "string"}}}]
+            :responses {200 {:description "Ok"
+                             ::openapi/content {"application/json" (st/schema [SuosikitVertailuItem])}}
+                        404 {:description "Not found"}}}}}}))
+
+(def paths (spec-paths-to-swagger-yaml suosikit-paths-spec))
 
 (def routes
   (c/routes

--- a/src/konfo_backend/suosikit/api.clj
+++ b/src/konfo_backend/suosikit/api.clj
@@ -25,7 +25,33 @@
    |              type: string
    |          required: true
    |          description: Pilkulla erotettu lista hakukohteiden oideja
-   |          example: kielivalikoima
+   |      responses:
+   |        '200':
+   |          description: Ok
+   |          content:
+   |            application/json:
+   |              schema:
+   |                type: json
+   |        '404':
+   |          description: Not found
+   |  /suosikit-vertailu:
+   |    get:
+   |      tags:
+   |        - internal
+   |      summary: Hae hakukohteille vertailutietoja
+   |      description: Hae annetuilla hakukohde-oideilla tietoja suosikkien vertailua varten
+   |        Huom.! Vain Opintopolun sisäiseen käyttöön
+   |      parameters:
+   |        - in: query
+   |          name: hakukohde-oids
+   |          style: form
+   |          explode: false
+   |          schema:
+   |            type: array
+   |            items:
+   |              type: string
+   |          required: true
+   |          description: Pilkulla erotettu lista hakukohteiden oideja
    |      responses:
    |        '200':
    |          description: Ok
@@ -42,5 +68,11 @@
      :query-params [{hakukohde-oids :- String nil}]
      (with-access-logging request
        (if-let [result (suosikit/get-by-hakukohde-oids (comma-separated-string->vec hakukohde-oids))]
+         (ok result)
+         (not-found "Not found"))))
+   (c/GET "/suosikit-vertailu" [:as request]
+     :query-params [{hakukohde-oids :- String nil}]
+     (with-access-logging request
+       (if-let [result (suosikit/get-vertailu-by-hakukohde-oids (comma-separated-string->vec hakukohde-oids))]
          (ok result)
          (not-found "Not found"))))))

--- a/src/konfo_backend/suosikit/api.clj
+++ b/src/konfo_backend/suosikit/api.clj
@@ -55,6 +55,7 @@
                                              :example "1.2.246.562.17.00000000000000000009"})
               :logo (st/schema s/Str {:description "Hakukohteen järjestyspaikan oppilaitoksen logon URL"})
               :esittely (st/schema Kuvaus {:description "Hakukohteen järjestyspaikan oppilaitoksen esittely eri kielillä"})
+              :jarjestyspaikka (st/schema Organisaatio {:description "Hakukohteen järjestyspaikan tiedot"})
               :osoite (st/schema KayntiOsoite {:description "Hakukohteen järjestyspaikan käyntiosoite"})
               (s/optional-key :opiskelijoita) (st/schema s/Int {:description "Hakukohteen järjestyspaikan oppilaitoksen opiskelijoiden määrä"})
               (s/optional-key :osaamisalat) (st/schema [AmmOsaamisala] {:description "Lista ammatillisen koulutuksen osaamisalojen kuvauksia"})

--- a/src/konfo_backend/suosikit/api.clj
+++ b/src/konfo_backend/suosikit/api.clj
@@ -29,6 +29,7 @@
    :hakukohdeOid (st/schema s/Str {:description "Hakukohteen yksilöivä tunniste"})
    :toteutusOid (st/schema s/Str {:description "Hakukohteeseen liitetyn toteutuksen yksilöivä tunniste"
                                   :example "1.2.246.562.17.00000000000000000009"})
+   :oppilaitosNimi (st/schema Nimi {:description "Hakukohteen järjestyspaikan oppilaitoksen nimi"})
    :logo (st/schema s/Str {:description "Hakukohteen järjestyspaikan oppilaitoksen logon URL"})
    :esittely (st/schema Kuvaus {:description "Hakukohteen järjestyspaikan oppilaitoksen esittely eri kielillä"})
    (s/optional-key :tutkintonimikkeet) (st/schema [(->Koodi s/Str)] {:description "Lista tutkintonimikkeitä käännöksineen (tutkintonimikkeet-koodisto)"})
@@ -53,9 +54,10 @@
               :hakukohdeOid (st/schema s/Str {:description "Hakukohteen yksilöivä tunniste"})
               :toteutusOid (st/schema s/Str {:description "Hakukohteeseen liitetyn toteutuksen yksilöivä tunniste"
                                              :example "1.2.246.562.17.00000000000000000009"})
+              :hakuOid (st/schema s/Str {:description "Hakukohteeseen liitetyn haun yksilöivä tunniste"})
               :logo (st/schema s/Str {:description "Hakukohteen järjestyspaikan oppilaitoksen logon URL"})
               :esittely (st/schema Kuvaus {:description "Hakukohteen järjestyspaikan oppilaitoksen esittely eri kielillä"})
-              :jarjestyspaikka (st/schema Organisaatio {:description "Hakukohteen järjestyspaikan tiedot"})
+              :oppilaitosNimi (st/schema Nimi {:description "Hakukohteen järjestyspaikan oppilaitoksen nimi"})
               :osoite (st/schema KayntiOsoite {:description "Hakukohteen järjestyspaikan käyntiosoite"})
               (s/optional-key :opiskelijoita) (st/schema s/Int {:description "Hakukohteen järjestyspaikan oppilaitoksen opiskelijoiden määrä"})
               (s/optional-key :osaamisalat) (st/schema [AmmOsaamisala] {:description "Lista ammatillisen koulutuksen osaamisalojen kuvauksia"})

--- a/src/konfo_backend/suosikit/suosikit.clj
+++ b/src/konfo_backend/suosikit/suosikit.clj
@@ -79,6 +79,7 @@
                                         (get-in [:metadata :pistehistoria])
                                         (last))
                      :valintakokeet (:valintakokeet hk)
+                     :jarjestyspaikka (:jarjestyspaikka hk)
                      :toinenAsteOnkoKaksoistutkinto (:toinenAsteOnkoKaksoistutkinto hk)
                      :jarjestaaUrheilijanAmmKoulutusta (get-in hk [:metadata :jarjestaaUrheilijanAmmKoulutusta])
                      :lukiodiplomit (get-in toteutus [:metadata :diplomit])

--- a/src/konfo_backend/suosikit/suosikit.clj
+++ b/src/konfo_backend/suosikit/suosikit.clj
@@ -41,6 +41,7 @@
                      (mapcat :hakukohteet)
                      (map (fn [hk] (let [oppilaitos (get-in orgs-by-oid [(get-in hk [:jarjestyspaikka :oid]) :oppilaitos])]
                                      (-> hk
+                                         (assoc :oppilaitosNimi (get-in oppilaitos [:organisaatio :nimi]))
                                          (assoc :esittely (get-in oppilaitos [:metadata :esittely]))
                                          (assoc :logo (get-in oppilaitos [:logo]))
                                          (assoc :toteutusOid (get-in t [:oid]))
@@ -64,6 +65,8 @@
                             :hakukohdeOid (:oid hakukohde)
                             :nimi (:nimi hakukohde)
                             :logo (:logo oppilaitos)
+                            :hakuOid (:hakuOid hakukohde)
+                            :oppilaitosNimi (get-in oppilaitos [:organisaatio :nimi])
                             :esittely (get-in oppilaitos [:metadata :esittely])
                             :osoite (-> oppilaitos
                                         (get-in [:metadata :yhteystiedot])
@@ -75,7 +78,6 @@
                                                (get-in [:metadata :pistehistoria])
                                                (last))
                             :valintakokeet (:valintakokeet hakukohde)
-                            :jarjestyspaikka (:jarjestyspaikka hakukohde)
                             :toinenAsteOnkoKaksoistutkinto (:toinenAsteOnkoKaksoistutkinto hakukohde)
                             :jarjestaaUrheilijanAmmKoulutusta (get-in hakukohde [:metadata :jarjestaaUrheilijanAmmKoulutusta])
                             :lukiodiplomit (get-in toteutus-metadata [:diplomit])

--- a/src/konfo_backend/suosikit/suosikit.clj
+++ b/src/konfo_backend/suosikit/suosikit.clj
@@ -75,7 +75,7 @@
                      :aloituspaikat nil ;TODO
                      :ensisijaisetHakijat nil ;TODO
                      :opiskelijoita (get-in oppilaitos [:metadata :opiskelijoita])
-                     :osaamisalat (get-in hk [:metadata :osaamisalat])
+                     :osaamisalat (get-in toteutus [:metadata :osaamisalat])
                      :valintakokeet (:valintakokeet hk)
                      :toinenAsteOnkoKaksoistutkinto (:toinenAsteOnkoKaksoistutkinto hk)
                      :jarjestaaUrheilijanAmmKoulutusta (get-in hk [:metadata :jarjestaaUrheilijanAmmKoulutusta])

--- a/src/konfo_backend/suosikit/suosikit.clj
+++ b/src/konfo_backend/suosikit/suosikit.clj
@@ -17,6 +17,7 @@
                                       "koulutusOid"
                                       "oid"
                                       "tila"
+                                      "metadata.kuvaus"
                                       "metadata.hakuaika"
                                       "hakutiedot.hakukohteet.nimi"
                                       "hakutiedot.hakukohteet.jarjestyspaikka"
@@ -36,16 +37,16 @@
          (map (fn [toteutus] (-> toteutus
                                  (#(assoc % :hakuAuki (toteutus-haku-kaynnissa? %)))
                                  (#(assoc % :hakutiedot (with-is-haku-auki (:hakutiedot %)))))))
-         (map (fn [t]
-                (->> (:hakutiedot t)
+         (map (fn [toteutus]
+                (->> (:hakutiedot toteutus)
                      (mapcat :hakukohteet)
                      (map (fn [hk] (let [oppilaitos (get-in orgs-by-oid [(get-in hk [:jarjestyspaikka :oid]) :oppilaitos])]
                                      (-> hk
                                          (assoc :oppilaitosNimi (get-in oppilaitos [:organisaatio :nimi]))
-                                         (assoc :esittely (get-in oppilaitos [:metadata :esittely]))
+                                         (assoc :esittely (get-in toteutus [:metadata :kuvaus]))
                                          (assoc :logo (get-in oppilaitos [:logo]))
-                                         (assoc :toteutusOid (get-in t [:oid]))
-                                         (assoc :tutkintonimikkeet (get-in koulutukset [(:koulutusOid t) :metadata :tutkintonimike])))))))))
+                                         (assoc :toteutusOid (get-in toteutus [:oid]))
+                                         (assoc :tutkintonimikkeet (get-in koulutukset [(:koulutusOid toteutus) :metadata :tutkintonimike])))))))))
          (flatten)
          (filter #(contains? hakukohde-oids (:hakukohdeOid %))))))
 
@@ -67,7 +68,7 @@
                             :logo (:logo oppilaitos)
                             :hakuOid (:hakuOid hakukohde)
                             :oppilaitosNimi (get-in oppilaitos [:organisaatio :nimi])
-                            :esittely (get-in oppilaitos [:metadata :esittely])
+                            :esittely (get-in toteutus-metadata [:kuvaus])
                             :osoite (-> oppilaitos
                                         (get-in [:metadata :yhteystiedot])
                                         (first)

--- a/src/konfo_backend/suosikit/suosikit.clj
+++ b/src/konfo_backend/suosikit/suosikit.clj
@@ -52,7 +52,7 @@
 (defn get-vertailu-by-hakukohde-oids
   [hakukohde-oids-seq]
   (let [hakukohde-oids (set hakukohde-oids-seq)
-        hakukohteet (hakukohde/get-many hakukohde-oids)
+        hakukohteet (filter julkaistu? (hakukohde/get-many hakukohde-oids))
         toteutukset-by-oid (into {} (map #(vec [(:oid %) %]) (toteutus/get-many (distinct (map :toteutusOid hakukohteet)))))
         oppilaitokset-res (oppilaitos/get-many (distinct (mapcat :oppilaitokset (vals toteutukset-by-oid))) false)
         osat-by-oid (mapcat #(map (fn [osa] [(:oid osa) %]) (:osat %)) oppilaitokset-res)

--- a/src/konfo_backend/suosikit/suosikit.clj
+++ b/src/konfo_backend/suosikit/suosikit.clj
@@ -63,19 +63,21 @@
         orgs-by-oid (into {} (concat osat-by-oid oppilaitokset-by-oid))]
     (map (fn [hk] (let [toteutus (get-in toteutukset-by-oid [(:toteutusOid hk)])
                         oppilaitos (get-in orgs-by-oid [(get-in hk [:jarjestyspaikka :oid]) :oppilaitos])]
-                    {:toteutusOid (:toteutusOid hk)
+                    {:koulutustyyppi (get-in toteutus [:metadata :tyyppi])
+                     :toteutusOid (:toteutusOid hk)
                      :hakukohdeOid (:oid hk)
                      :nimi (:nimi hk)
+                     :logo (:logo oppilaitos)
                      :esittely (get-in oppilaitos [:metadata :esittely])
                      :osoite (-> oppilaitos
                                  (get-in [:metadata :yhteystiedot])
                                  (first)
                                  (get-in [:kayntiosoiteStr]))
-                     :alinPistemaara nil ;TODO
-                     :aloituspaikat nil ;TODO
-                     :ensisijaisetHakijat nil ;TODO
                      :opiskelijoita (get-in oppilaitos [:metadata :opiskelijoita])
                      :osaamisalat (get-in toteutus [:metadata :osaamisalat])
+                     :edellinenHaku (-> hk
+                                        (get-in [:metadata :pistehistoria])
+                                        (last))
                      :valintakokeet (:valintakokeet hk)
                      :toinenAsteOnkoKaksoistutkinto (:toinenAsteOnkoKaksoistutkinto hk)
                      :jarjestaaUrheilijanAmmKoulutusta (get-in hk [:metadata :jarjestaaUrheilijanAmmKoulutusta])

--- a/src/konfo_backend/suosikit/suosikit.clj
+++ b/src/konfo_backend/suosikit/suosikit.clj
@@ -4,10 +4,10 @@
    [konfo-backend.search.response :refer [hits]]
    [konfo-backend.elastic-tools :refer [search]]
    [konfo-backend.util.haku-auki :refer [with-is-haku-auki]]
+   [konfo-backend.index.hakukohde :as hakukohde]
    [konfo-backend.index.toteutus :as toteutus]
    [konfo-backend.index.oppilaitos :as oppilaitos]
    [konfo-backend.index.koulutus :as koulutus]))
-
 
 (defn get-by-hakukohde-oids
   [hakukohde-oids-seq]
@@ -31,7 +31,7 @@
         oppilaitokset-res (oppilaitos/get-many (distinct (mapcat :oppilaitokset toteutukset)) false)
         osat-by-oid (mapcat #(map (fn [osa] [(:oid osa) %]) (:osat %)) oppilaitokset-res)
         oppilaitokset-by-oid (map (fn [oppilaitos] [(:oid oppilaitos) oppilaitos]) oppilaitokset-res)
-        orgs-by-oid (into {} (concat osat-by-oid oppilaitokset-by-oid))] 
+        orgs-by-oid (into {} (concat osat-by-oid oppilaitokset-by-oid))]
     (->> toteutukset
          (map #(toteutus/filter-haut-and-hakukohteet % false))
          (map (fn [toteutus] (-> toteutus
@@ -48,3 +48,37 @@
                                          (assoc :tutkintonimikkeet (get-in koulutukset [(:koulutusOid t) :metadata :tutkintonimike])))))))))
          (flatten)
          (filter #(contains? hakukohde-oids (:hakukohdeOid %))))))
+
+(defn into-map-by [get-key items]
+  (into {} (map #(vec [(get-key %) %]) items)))
+
+(defn get-vertailu-by-hakukohde-oids
+  [hakukohde-oids-seq]
+  (let [hakukohde-oids (set hakukohde-oids-seq)
+        hakukohteet (hakukohde/get-many hakukohde-oids)
+        toteutukset-by-oid (into-map-by :oid (toteutus/get-many (distinct (map :toteutusOid hakukohteet))))
+        oppilaitokset-res (oppilaitos/get-many (distinct (mapcat :oppilaitokset (vals toteutukset-by-oid))) false)
+        osat-by-oid (mapcat #(map (fn [osa] [(:oid osa) %]) (:osat %)) oppilaitokset-res)
+        oppilaitokset-by-oid (map (fn [oppilaitos] [(:oid oppilaitos) oppilaitos]) oppilaitokset-res)
+        orgs-by-oid (into {} (concat osat-by-oid oppilaitokset-by-oid))]
+    (map (fn [hk] (let [toteutus (get-in toteutukset-by-oid [(:toteutusOid hk)])
+                        oppilaitos (get-in orgs-by-oid [(get-in hk [:jarjestyspaikka :oid]) :oppilaitos])]
+                    {:toteutusOid (:toteutusOid hk)
+                     :hakukohdeOid (:oid hk)
+                     :nimi (:nimi hk)
+                     :esittely (get-in oppilaitos [:metadata :esittely])
+                     :osoite (-> oppilaitos
+                                 (get-in [:metadata :yhteystiedot])
+                                 (first)
+                                 (get-in [:kayntiosoiteStr]))
+                     :alinPistemaara nil ;TODO
+                     :aloituspaikat nil ;TODO
+                     :ensisijaisetHakijat nil ;TODO
+                     :opiskelijoita (get-in oppilaitos [:metadata :opiskelijoita])
+                     :osaamisalat (get-in hk [:metadata :osaamisalat])
+                     :valintakokeet (:valintakokeet hk)
+                     :toinenAsteOnkoKaksoistutkinto (:toinenAsteOnkoKaksoistutkinto hk)
+                     :jarjestaaUrheilijanAmmKoulutusta (get-in hk [:metadata :jarjestaaUrheilijanAmmKoulutusta])
+                     :lukiodiplomit (get-in toteutus [:metadata :diplomit])
+                     :kielivalikoima (get-in toteutus [:metadata :kielivalikoima])}))
+         hakukohteet)))

--- a/test/konfo_backend/suosikit/suosikit_test.clj
+++ b/test/konfo_backend/suosikit/suosikit_test.clj
@@ -23,8 +23,8 @@
       (testing "ok"
         (let [response (get-ok (suosikit-url [suosikki-hakukohde-oid1]))]
           (is (match? [{:tila "julkaistu"
-                        :esittely {:fi "Esittely"
-                                   :sv "Esittely sv"}
+                        :esittely {:fi "kuvaus"
+                                   :sv "kuvaus sv"}
                         :logo "https://testi.fi/oppilaitos-logo/oid/logo.png"
                         :toteutusOid "1.2.246.562.17.000001"
                         :oppilaitosNimi {:fi "Jokin järjestyspaikka"
@@ -63,8 +63,8 @@
                          :toteutusOid "1.2.246.562.17.000001"
                          :hakuOid "1.2.246.562.29.0000001"
                          :logo "https://testi.fi/oppilaitos-logo/oid/logo.png"
-                         :esittely {:fi "Esittely"
-                                    :sv "Esittely sv"}
+                         :esittely {:fi "kuvaus"
+                                    :sv "kuvaus sv"}
                          :oppilaitosNimi {:fi "Jokin järjestyspaikka"
                                           :sv "Jokin järjestyspaikka sv"}
                          :osoite {}

--- a/test/konfo_backend/suosikit/suosikit_test.clj
+++ b/test/konfo_backend/suosikit/suosikit_test.clj
@@ -27,6 +27,8 @@
                                    :sv "Esittely sv"}
                         :logo "https://testi.fi/oppilaitos-logo/oid/logo.png"
                         :toteutusOid "1.2.246.562.17.000001"
+                        :oppilaitosNimi {:fi "Jokin järjestyspaikka"
+                                         :sv "Jokin järjestyspaikka sv"}
                         :jarjestyspaikka {:nimi {:fi "Jokin järjestyspaikka"
                                                  :sv "Jokin järjestyspaikka sv"}
                                           :paikkakunta {:koodiUri "kunta_297"
@@ -59,15 +61,12 @@
                          :nimi {:fi "Hakukohde fi" :sv "Hakukohde sv"}
                          :hakukohdeOid "1.2.246.562.20.0000001"
                          :toteutusOid "1.2.246.562.17.000001"
-                         :jarjestyspaikka {:nimi {:fi "Jokin järjestyspaikka"
-                                                  :sv "Jokin järjestyspaikka sv"}
-                                           :paikkakunta {:koodiUri "kunta_297"
-                                                         :nimi {:fi "kunta_297 nimi fi"
-                                                                :sv "kunta_297 nimi sv"}}
-                                           :oid "1.2.246.562.10.67476956288"}
+                         :hakuOid "1.2.246.562.29.0000001"
                          :logo "https://testi.fi/oppilaitos-logo/oid/logo.png"
                          :esittely {:fi "Esittely"
                                     :sv "Esittely sv"}
+                         :oppilaitosNimi {:fi "Jokin järjestyspaikka"
+                                          :sv "Jokin järjestyspaikka sv"}
                          :osoite {}
                          :opiskelijoita 100
                          :osaamisalat [{:koodi {:koodiUri "osaamisala_0001#1"

--- a/test/konfo_backend/suosikit/suosikit_test.clj
+++ b/test/konfo_backend/suosikit/suosikit_test.clj
@@ -17,39 +17,41 @@
   (apply url-with-query-params "/konfo-backend/suosikit-vertailu" [:hakukohde-oids hakukohde-oids]))
 
 (deftest suosikit-test
+  (set-fixed-time "2020-01-02T12:00:01")
   (let [suosikki-hakukohde-oid1  "1.2.246.562.20.0000001"]
     (testing "Get suosikit"
       (testing "ok"
         (let [response (get-ok (suosikit-url [suosikki-hakukohde-oid1]))]
-          (is (match?  [{:tila "julkaistu"
-                         :esittely {:fi "Esittely"
-                                    :sv "Esittely sv"}
-                         :logo "https://testi.fi/oppilaitos-logo/oid/logo.png"
-                         :toteutusOid "1.2.246.562.17.000001"
-                         :jarjestyspaikka {:nimi {:fi "Jokin järjestyspaikka"
-                                                  :sv "Jokin järjestyspaikka sv"}
-                                           :paikkakunta {:koodiUri "kunta_297"
-                                                         :nimi {:fi "kunta_297 nimi fi"
-                                                                :sv "kunta_297 nimi sv"}}
-                                           :oid "1.2.246.562.10.67476956288"}
-                         :nimi {:fi "nimi fi" :sv "nimi sv"}
-                         :hakuajat [{:formatoituAlkaa {:fi "11.10.2023 klo 09:49"
-                                                       :sv "11.10.2023 kl. 09:49"
-                                                       :en "Oct. 11, 2023 at 09:49 am UTC+3"}
-                                     :formatoituPaattyy {:fi "11.10.2023 klo 09:58"
-                                                         :sv "11.10.2023 kl. 09:58"
-                                                         :en "Oct. 11, 2023 at 09:58 am UTC+3"}
-                                     :alkaa "2023-10-11T09:49"
-                                     :paattyy "2023-10-11T09:58"
-                                     :hakuAuki false
-                                     :hakuMennyt true}]
-                         :tutkintonimikkeet [{:koodiUri "tutkintonimikkeet_01"
-                                              :nimi {:fi "tutkintonimikkeet_01 nimi fi"
-                                                     :sv "tutkintonimikkeet_01 nimi sv"}}
-                                             {:koodiUri "tutkintonimikkeet_02"
-                                              :nimi {:fi "tutkintonimikkeet_02 nimi fi"
-                                                     :sv "tutkintonimikkeet_02 nimi sv"}}]
-                         :hakukohdeOid "1.2.246.562.20.0000001"}] response)))))
+          (is (match? [{:tila "julkaistu"
+                        :esittely {:fi "Esittely"
+                                   :sv "Esittely sv"}
+                        :logo "https://testi.fi/oppilaitos-logo/oid/logo.png"
+                        :toteutusOid "1.2.246.562.17.000001"
+                        :jarjestyspaikka {:nimi {:fi "Jokin järjestyspaikka"
+                                                 :sv "Jokin järjestyspaikka sv"}
+                                          :paikkakunta {:koodiUri "kunta_297"
+                                                        :nimi {:fi "kunta_297 nimi fi"
+                                                               :sv "kunta_297 nimi sv"}}
+                                          :oid "1.2.246.562.10.67476956288"}
+                        :nimi {:fi "nimi fi" :sv "nimi sv"}
+                        :hakuajat [{:formatoituAlkaa {:fi "11.10.2023 klo 09:49"
+                                                      :sv "11.10.2023 kl. 09:49"
+                                                      :en "Oct. 11, 2023 at 09:49 am UTC+3"}
+                                    :formatoituPaattyy {:fi "11.10.2023 klo 09:58"
+                                                        :sv "11.10.2023 kl. 09:58"
+                                                        :en "Oct. 11, 2023 at 09:58 am UTC+3"}
+                                    :alkaa "2023-10-11T09:49"
+                                    :paattyy "2023-10-11T09:58"
+                                    :hakuAuki false
+                                    :hakuMennyt false}]
+                        :tutkintonimikkeet [{:koodiUri "tutkintonimikkeet_01"
+                                             :nimi {:fi "tutkintonimikkeet_01 nimi fi"
+                                                    :sv "tutkintonimikkeet_01 nimi sv"}}
+                                            {:koodiUri "tutkintonimikkeet_02"
+                                             :nimi {:fi "tutkintonimikkeet_02 nimi fi"
+                                                    :sv "tutkintonimikkeet_02 nimi sv"}}]
+                        :hakukohdeOid "1.2.246.562.20.0000001"}]
+                      response)))))
     (testing "Get suosikit vertailu"
       (testing "ok"
         (let [response (get-ok (suosikit-vertailu-url [suosikki-hakukohde-oid1]))]

--- a/test/konfo_backend/suosikit/suosikit_test.clj
+++ b/test/konfo_backend/suosikit/suosikit_test.clj
@@ -12,9 +12,13 @@
   [hakukohde-oids]
   (apply url-with-query-params "/konfo-backend/suosikit" [:hakukohde-oids hakukohde-oids]))
 
+(defn suosikit-vertailu-url
+  [hakukohde-oids]
+  (apply url-with-query-params "/konfo-backend/suosikit-vertailu" [:hakukohde-oids hakukohde-oids]))
+
 (deftest suosikit-test
   (let [suosikki-hakukohde-oid1  "1.2.246.562.20.0000001"]
-    (testing "Get suosikki"
+    (testing "Get suosikit"
       (testing "ok"
         (let [response (get-ok (suosikit-url [suosikki-hakukohde-oid1]))]
           (is (match?  [{:tila "julkaistu"
@@ -25,8 +29,8 @@
                          :jarjestyspaikka {:nimi {:fi "Jokin järjestyspaikka"
                                                   :sv "Jokin järjestyspaikka sv"}
                                            :paikkakunta {:koodiUri "kunta_297"
-                                                         :nimi {:fi "kunta_297 nimi fi" :sv "kunta_297 nimi sv"}}
-                                           :jarjestaaUrheilijanAmmKoulutusta true
+                                                         :nimi {:fi "kunta_297 nimi fi"
+                                                                :sv "kunta_297 nimi sv"}}
                                            :oid "1.2.246.562.10.67476956288"}
                          :nimi {:fi "nimi fi" :sv "nimi sv"}
                          :hakuajat [{:formatoituAlkaa {:fi "11.10.2023 klo 09:49"
@@ -38,13 +42,76 @@
                                      :alkaa "2023-10-11T09:49"
                                      :paattyy "2023-10-11T09:58"
                                      :hakuAuki false
-                                     :hakuMennyt false}]
+                                     :hakuMennyt true}]
                          :tutkintonimikkeet [{:koodiUri "tutkintonimikkeet_01"
-                                              :nimi
-                                              {:fi "tutkintonimikkeet_01 nimi fi"
-                                               :sv "tutkintonimikkeet_01 nimi sv"}}
+                                              :nimi {:fi "tutkintonimikkeet_01 nimi fi"
+                                                     :sv "tutkintonimikkeet_01 nimi sv"}}
                                              {:koodiUri "tutkintonimikkeet_02"
-                                              :nimi
-                                              {:fi "tutkintonimikkeet_02 nimi fi"
-                                               :sv "tutkintonimikkeet_02 nimi sv"}}]
-                         :hakukohdeOid "1.2.246.562.20.0000001"}] response)))))))
+                                              :nimi {:fi "tutkintonimikkeet_02 nimi fi"
+                                                     :sv "tutkintonimikkeet_02 nimi sv"}}]
+                         :hakukohdeOid "1.2.246.562.20.0000001"}] response)))))
+    (testing "Get suosikit vertailu"
+      (testing "ok"
+        (let [response (get-ok (suosikit-vertailu-url [suosikki-hakukohde-oid1]))]
+          (is (match?  [{:koulutustyyppi "amm"
+                         :nimi {:fi "Hakukohde fi" :sv "Hakukohde sv"}
+                         :hakukohdeOid "1.2.246.562.20.0000001"
+                         :toteutusOid "1.2.246.562.17.000001"
+                         :jarjestyspaikka {:nimi {:fi "Jokin järjestyspaikka"
+                                                  :sv "Jokin järjestyspaikka sv"}
+                                           :paikkakunta {:koodiUri "kunta_297"
+                                                         :nimi {:fi "kunta_297 nimi fi"
+                                                                :sv "kunta_297 nimi sv"}}
+                                           :oid "1.2.246.562.10.67476956288"}
+                         :logo "https://testi.fi/oppilaitos-logo/oid/logo.png"
+                         :esittely {:fi "Esittely"
+                                    :sv "Esittely sv"}
+                         :osoite {}
+                         :opiskelijoita 100
+                         :osaamisalat [{:koodi {:koodiUri "osaamisala_0001#1"
+                                                :nimi {:fi "osaamisala_0001#1 nimi fi"
+                                                       :sv "osaamisala_0001#1 nimi sv"}}
+                                        :linkki {:fi "http://osaamisala.fi/linkki/fi"
+                                                 :sv "http://osaamisala.fi/linkki/sv"}
+                                        :otsikko {:fi "Katso osaamisalan tarkempi kuvaus tästä"
+                                                  :sv "Katso osaamisalan tarkempi kuvaus tästä sv"}}]
+                         :edellinenHaku nil
+                         :jarjestaaUrheilijanAmmKoulutusta false
+                         :valintakokeet
+                         [{:id "f50c7536-1c50-4fa8-b13c-514877be71a0"
+                           :tyyppi {:koodiUri "valintakokeentyyppi_1#1"
+                                    :nimi
+                                    {:fi "valintakokeentyyppi_1#1 nimi fi"
+                                     :sv "valintakokeentyyppi_1#1 nimi sv"}}
+                           :nimi {:fi "valintakokeen nimi fi" :sv "valintakokeen nimi sv"}
+                           :metadata {:tietoja
+                                      {:fi "tietoa valintakokeesta fi"
+                                       :sv "tietoa valintakokeesta sv"}
+                                      :vahimmaispisteet 182.1
+                                      :liittyyEnnakkovalmistautumista true
+                                      :ohjeetEnnakkovalmistautumiseen
+                                      {:fi "Ennakko-ohjeet fi" :sv "Ennakko-ohjeet sv"}
+                                      :erityisjarjestelytMahdollisia true
+                                      :ohjeetErityisjarjestelyihin
+                                      {:fi "Erityisvalmistelut fi" :sv "Erityisvalmistelut sv"}}
+                           :tilaisuudet [{:osoite
+                                          {:osoite {:fi "Kivatie 1" :sv "kivavägen 1"}
+                                           :postinumero
+                                           {:koodiUri "posti_04230#2"
+                                            :nimi
+                                            {:fi "posti_04230#2 nimi fi" :sv "posti_04230#2 nimi sv"}}}
+                                          :aika
+                                          {:alkaa "2023-10-11T09:49"
+                                           :paattyy "2023-10-11T09:58"
+                                           :formatoituPaattyy
+                                           {:fi "11.10.2023 klo 09:58"
+                                            :sv "11.10.2023 kl. 09:58"
+                                            :en "Oct. 11, 2023 at 09:58 am UTC+3"}
+                                           :formatoituAlkaa
+                                           {:fi "11.10.2023 klo 09:49"
+                                            :sv "11.10.2023 kl. 09:49"
+                                            :en "Oct. 11, 2023 at 09:49 am UTC+3"}}
+                                          :jarjestamispaikka
+                                          {:fi "Järjestämispaikka fi" :sv "Järjestämispaikka sv"}
+                                          :lisatietoja {:fi "lisätieto fi" :sv "lisätieto sv"}}]}]}]
+                       response)))))))


### PR DESCRIPTION
OK-376: Lisätty rajapinta, josta saa noudettua tiedot suosikkien vertailua varten.

Swagger-määrittelyiden helpottamiseksi otettu käyttöön `schema-tools.openapi.core`-namespace, ja toteutettu muutama työkalufunktio skeemojen muuntamiseksi nykyiseen YML-string-muotoon. Ainoastaan muutama yleisesti käytetty skeema sekä /suosikit ja /suosikit-vertailu swagger-määrittelyt toteutettu schema-toolsilla.