### PR TITLE
OY-4585 Allow for empty pohjakoulutusvaatimus match in filter

### DIFF
--- a/src/konfo_backend/search/rajain_counts.clj
+++ b/src/konfo_backend/search/rajain_counts.clj
@@ -3,7 +3,8 @@
             [konfo-backend.index.oppilaitos :as oppilaitos]
             [konfo-backend.koodisto.koodisto :as k]
             [konfo-backend.tools :refer [koodi-uri-no-version reduce-merge-map]]
-            [konfo-backend.index.lokalisointi :as lokalisointi]))
+            [konfo-backend.index.lokalisointi :as lokalisointi]
+            [clojure.string :as str]))
 
 (defn- koodi->rajain-counts
   [rajain-counts koodi]
@@ -172,6 +173,28 @@
             {}
             rajain-counts)))
 
+(defn- add-missing-counts-to-codes
+  [rajain-counts prefix missing-code]
+  (let [missing-count (get rajain-counts missing-code 0)
+        counts-without-missing (dissoc rajain-counts missing-code)
+        add-missing-count-fn (fn [code count] (if (str/starts-with? (name code) prefix)
+                                                (+ count missing-count)
+                                                count))]
+      (reduce (fn [final-counts [code count]]
+                (assoc final-counts code (add-missing-count-fn code count)))
+              {}
+              counts-without-missing)))
+
+(defn- pohjakoulutusvaatimus-counts
+  [rajain-counts]
+  ; All pohjakoulutusvaatimus results should include values (and hence counts) from
+  ; documents that are missing the code set value - interpreted as "ei pohjakoulutusvaatimusta"
+  (let [counts-with-missing (add-missing-counts-to-codes rajain-counts
+                                                         "pohjakoulutusvaatimuskonfo"
+                                                         :pohjakoulutusvaatimuskonfo_missing)
+        counts (koodisto->rajain-counts counts-with-missing "pohjakoulutusvaatimuskonfo")]
+    counts))
+
 (defn generate-default-rajain-counts
   ([rajain-counts]
    (let [koodisto-counts (partial koodisto->rajain-counts rajain-counts)]
@@ -190,7 +213,7 @@
       :tyovoimakoulutus (tyovoimakoulutus rajain-counts)
       :taydennyskoulutus (taydennyskoulutus rajain-counts)
       :yhteishaku (yhteishaku rajain-counts)
-      :pohjakoulutusvaatimus (koodisto-counts "pohjakoulutusvaatimuskonfo")
+      :pohjakoulutusvaatimus (pohjakoulutusvaatimus-counts rajain-counts)
       :osaamisala (koodisto-counts "osaamisala")
       :lukiolinjaterityinenkoulutustehtava (koodisto-counts "lukiolinjaterityinenkoulutustehtava")
       :lukiopainotukset (koodisto-counts "lukiopainotukset")

--- a/src/konfo_backend/search/rajain_definitions.clj
+++ b/src/konfo_backend/search/rajain_definitions.clj
@@ -392,7 +392,7 @@
 
 (def pohjakoulutusvaatimus
   {:id :pohjakoulutusvaatimus
-   :make-query #(nested-query "hakutiedot" "pohjakoulutusvaatimukset" %)
+   :make-query #(pohjakoulutusvaatimukset-filter-query %)
    :make-agg (fn [constraints rajain-context]
                (nested-rajain-aggregation "pohjakoulutusvaatimus" "search_terms.hakutiedot.pohjakoulutusvaatimukset"
                                           (aggregation-filters-without-rajainkeys constraints ["pohjakoulutusvaatimus"] rajain-context)

--- a/src/konfo_backend/search/rajain_definitions.clj
+++ b/src/konfo_backend/search/rajain_definitions.clj
@@ -3,7 +3,8 @@
    [konfo-backend.tools :refer [current-time-as-kouta-format]]
    [clj-time.core :as time]
    [clojure.string :refer [replace-first]]
-   [konfo-backend.search.rajain-tools :refer :all]))
+   [konfo-backend.search.rajain-tools :refer :all]
+   [clojure.tools.logging :as log]))
 
 ;; Esitellään myöhemmin alustettu muuttuja ristikkäisten riippuvuuksien vuoksi. Tätä käytetään heti
 ;; alla olevissa funktioissa, vaikka varsinaiset sisällöt (rajain-määritykset) asetetaan vasta 
@@ -396,7 +397,7 @@
    :make-agg (fn [constraints rajain-context]
                (nested-rajain-aggregation "pohjakoulutusvaatimus" "search_terms.hakutiedot.pohjakoulutusvaatimukset"
                                           (aggregation-filters-without-rajainkeys constraints ["pohjakoulutusvaatimus"] rajain-context)
-                                          rajain-context))
+                                          rajain-context "pohjakoulutusvaatimuskonfo"))
    :desc "
         - in: query
           name: pohjakoulutusvaatimus

--- a/src/konfo_backend/search/rajain_definitions.clj
+++ b/src/konfo_backend/search/rajain_definitions.clj
@@ -3,8 +3,7 @@
    [konfo-backend.tools :refer [current-time-as-kouta-format]]
    [clj-time.core :as time]
    [clojure.string :refer [replace-first]]
-   [konfo-backend.search.rajain-tools :refer :all]
-   [clojure.tools.logging :as log]))
+   [konfo-backend.search.rajain-tools :refer :all]))
 
 ;; Esitellään myöhemmin alustettu muuttuja ristikkäisten riippuvuuksien vuoksi. Tätä käytetään heti
 ;; alla olevissa funktioissa, vaikka varsinaiset sisällöt (rajain-määritykset) asetetaan vasta 
@@ -397,7 +396,7 @@
    :make-agg (fn [constraints rajain-context]
                (nested-rajain-aggregation "pohjakoulutusvaatimus" "search_terms.hakutiedot.pohjakoulutusvaatimukset"
                                           (aggregation-filters-without-rajainkeys constraints ["pohjakoulutusvaatimus"] rajain-context)
-                                          rajain-context "pohjakoulutusvaatimuskonfo"))
+                                          (merge rajain-context {:term-params {:missing "pohjakoulutusvaatimuskonfo_missing"}})))
    :desc "
         - in: query
           name: pohjakoulutusvaatimus

--- a/src/konfo_backend/search/rajain_tools.clj
+++ b/src/konfo_backend/search/rajain_tools.clj
@@ -93,6 +93,16 @@
                        {:nested {:path "search_terms.hakutiedot.hakuajat"
                                  :query {:range {:search_terms.hakutiedot.hakuajat.alkaa {:gt current-time :lte max-time}}}}}]}})))
 
+(defn pohjakoulutusvaatimukset-filter-query
+  [pohjakoulutusvaatimukset]
+  (when pohjakoulutusvaatimukset
+    {:nested
+     {:path "search_terms.hakutiedot"
+      :query
+      {:bool
+       {:should [{:bool {:filter (->terms-query "hakutiedot.pohjakoulutusvaatimukset" pohjakoulutusvaatimukset)}}
+                 {:bool {:must_not {:exists {:field "search_terms.hakutiedot.pohjakoulutusvaatimukset"}}}}]}}}}))
+
 
 (defn ->field-key [field-name]
   (str "search_terms." (name field-name)))

--- a/src/konfo_backend/search/rajain_tools.clj
+++ b/src/konfo_backend/search/rajain_tools.clj
@@ -122,11 +122,11 @@
    (with-real-hits agg nil)))
 
 (defn- rajain-terms-agg
-  ([field-name rajain-context]
-   (let [default-terms {:field field-name
-                        :min_doc_count 0
-                        :size 1000}]
-     (with-real-hits {:terms (merge default-terms (get-in rajain-context [:term-params]))} rajain-context))))
+  [field-name rajain-context]
+  (let [default-terms {:field field-name
+                       :min_doc_count 0
+                       :size 1000}]
+    (with-real-hits {:terms (merge default-terms (get-in rajain-context [:term-params]))} rajain-context)))
 
 (defn- constrained-agg [constraints filtered-aggs plain-aggs]
   (if (not-empty constraints)
@@ -163,13 +163,13 @@
    (max-agg-filter field-name nil)))
 
 (defn nested-rajain-aggregation
-  ([rajain-key field-name constraints rajain-context]
-   (let [nested-agg {:nested  {:path (-> field-name
-                                         (replace-first ".keyword" "")
-                                         (split #"\.")
-                                         (drop-last) (#(join "." %)))}
-                     :aggs {:rajain (rajain-terms-agg field-name rajain-context)}}]
-     (constrained-agg
-      constraints
-      {(keyword rajain-key) nested-agg}
-      nested-agg))))
+  [rajain-key field-name constraints rajain-context]
+  (let [nested-agg {:nested  {:path (-> field-name
+                                        (replace-first ".keyword" "")
+                                        (split #"\.")
+                                        (drop-last) (#(join "." %)))}
+                    :aggs {:rajain (rajain-terms-agg field-name rajain-context)}}]
+    (constrained-agg
+     constraints
+     {(keyword rajain-key) nested-agg}
+     nested-agg)))

--- a/src/konfo_backend/search/rajain_tools.clj
+++ b/src/konfo_backend/search/rajain_tools.clj
@@ -122,16 +122,11 @@
    (with-real-hits agg nil)))
 
 (defn- rajain-terms-agg
-  ([field-name rajain-context missing-bucket-prefix]
-   (let [base-terms {:field field-name
-                     :min_doc_count 0
-                     :size 1000}
-         default-terms (if missing-bucket-prefix
-                         (assoc base-terms :missing (str missing-bucket-prefix "_missing"))
-                         base-terms)]
-     (with-real-hits {:terms (merge default-terms (get-in rajain-context [:term-params]))} rajain-context)))
   ([field-name rajain-context]
-   (rajain-terms-agg field-name rajain-context nil)))
+   (let [default-terms {:field field-name
+                        :min_doc_count 0
+                        :size 1000}]
+     (with-real-hits {:terms (merge default-terms (get-in rajain-context [:term-params]))} rajain-context))))
 
 (defn- constrained-agg [constraints filtered-aggs plain-aggs]
   (if (not-empty constraints)
@@ -168,15 +163,13 @@
    (max-agg-filter field-name nil)))
 
 (defn nested-rajain-aggregation
-  ([rajain-key field-name constraints rajain-context missing-bucket-prefix]
+  ([rajain-key field-name constraints rajain-context]
    (let [nested-agg {:nested  {:path (-> field-name
                                          (replace-first ".keyword" "")
                                          (split #"\.")
                                          (drop-last) (#(join "." %)))}
-                     :aggs {:rajain (rajain-terms-agg field-name rajain-context missing-bucket-prefix)}}]
+                     :aggs {:rajain (rajain-terms-agg field-name rajain-context)}}]
      (constrained-agg
       constraints
       {(keyword rajain-key) nested-agg}
-      nested-agg)))
-  ([rajain-key field-name constraints rajain-context]
-   (nested-rajain-aggregation rajain-key field-name constraints rajain-context nil)))
+      nested-agg))))

--- a/test/konfo_backend/search/query_unit_test.clj
+++ b/test/konfo_backend/search/query_unit_test.clj
@@ -146,7 +146,11 @@
                               :koulutusala (default-agg "search_terms.koulutusalat.keyword")
                               :yhteishaku (default-nested-agg :yhteishaku "search_terms.hakutiedot.yhteishakuOid")
                               :kunta (default-agg "search_terms.sijainti.keyword" nil {:include "kunta.*"} nil)
-                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus "search_terms.hakutiedot.pohjakoulutusvaatimukset")
+                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus
+                                                                         "search_terms.hakutiedot.pohjakoulutusvaatimukset"
+                                                                         nil
+                                                                         {:missing "pohjakoulutusvaatimuskonfo_missing"}
+                                                                         nil)
                               :maakunta (default-agg "search_terms.sijainti.keyword" nil {:include "maakunta.*"} nil)
                               :hakutapa (default-nested-agg :hakutapa "search_terms.hakutiedot.hakutapa")
                               :opetustapa (default-agg "search_terms.opetustavat.keyword")
@@ -226,7 +230,11 @@
                              {:koulutusala (default-agg "search_terms.koulutusalat.keyword" jotpa-bool-filter)
                               :yhteishaku (default-nested-agg :yhteishaku "search_terms.hakutiedot.yhteishakuOid" jotpa-bool-filter nil nil)
                               :kunta (default-agg "search_terms.sijainti.keyword" jotpa-bool-filter {:include "kunta.*"} nil)
-                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus "search_terms.hakutiedot.pohjakoulutusvaatimukset" jotpa-bool-filter nil nil)
+                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus
+                                                                         "search_terms.hakutiedot.pohjakoulutusvaatimukset"
+                                                                         jotpa-bool-filter
+                                                                         {:missing "pohjakoulutusvaatimuskonfo_missing"}
+                                                                         nil)
                               :maakunta (default-agg "search_terms.sijainti.keyword" jotpa-bool-filter {:include "maakunta.*"} nil)
                               :hakutapa (default-nested-agg :hakutapa "search_terms.hakutiedot.hakutapa" jotpa-bool-filter nil nil)
                               :opetustapa (default-agg "search_terms.opetustavat.keyword" jotpa-bool-filter)
@@ -326,7 +334,11 @@
                              {:yhteishaku (default-nested-agg :yhteishaku "search_terms.hakutiedot.yhteishakuOid" onkotuleva-sijainti-bool-filter nil "search_terms")
                               :kunta (default-agg "search_terms.sijainti.keyword" {:bool {:filter [onkotuleva-term]}} {:include "kunta.*"} "search_terms")
                               :maakunta (default-agg "search_terms.sijainti.keyword" {:bool {:filter [onkotuleva-term]}} {:include "maakunta.*"} "search_terms")
-                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus "search_terms.hakutiedot.pohjakoulutusvaatimukset" onkotuleva-sijainti-bool-filter nil "search_terms")
+                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus
+                                                                         "search_terms.hakutiedot.pohjakoulutusvaatimukset"
+                                                                         onkotuleva-sijainti-bool-filter
+                                                                         {:missing "pohjakoulutusvaatimuskonfo_missing"}
+                                                                         "search_terms")
                               :oppilaitos (default-agg "search_terms.oppilaitosOid.keyword" onkotuleva-sijainti-bool-filter {:min_doc_count 1
                                                                                                                              :size          10000} "search_terms")
                               :hakutapa (default-nested-agg :hakutapa "search_terms.hakutiedot.hakutapa" onkotuleva-sijainti-bool-filter nil "search_terms")
@@ -424,7 +436,11 @@
                              {:yhteishaku (default-nested-agg :yhteishaku "search_terms.hakutiedot.yhteishakuOid" onkotuleva-sijainti-bool-filter nil "search_terms")
                               :kunta (default-agg "search_terms.sijainti.keyword" {:bool {:filter [onkotuleva-term]}} {:include "kunta.*"} "search_terms")
                               :maakunta (default-agg "search_terms.sijainti.keyword" {:bool {:filter [onkotuleva-term]}} {:include "maakunta.*"} "search_terms")
-                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus "search_terms.hakutiedot.pohjakoulutusvaatimukset" onkotuleva-sijainti-bool-filter nil "search_terms")
+                              :pohjakoulutusvaatimus (default-nested-agg :pohjakoulutusvaatimus
+                                                                         "search_terms.hakutiedot.pohjakoulutusvaatimukset"
+                                                                         onkotuleva-sijainti-bool-filter
+                                                                         {:missing "pohjakoulutusvaatimuskonfo_missing"}
+                                                                         "search_terms")
                               :hakutapa (default-nested-agg :hakutapa "search_terms.hakutiedot.hakutapa" onkotuleva-sijainti-bool-filter nil "search_terms")
                               :opetustapa (default-agg "search_terms.opetustavat.keyword" onkotuleva-sijainti-bool-filter nil "search_terms")
                               :opetusaika (default-agg "search_terms.metadata.opetusajat.koodiUri.keyword" onkotuleva-sijainti-bool-filter nil "search_terms")

--- a/test/konfo_backend/search/rajain_definitions_unit_test.clj
+++ b/test/konfo_backend/search/rajain_definitions_unit_test.clj
@@ -42,10 +42,15 @@
                            "2022-08-26T07:21"))))
 
   (testing "Should form filter for the query with a hakutieto query"
-    (is (= [{:nested {:path  "search_terms.hakutiedot"
-                      :query {:bool
-                              {:filter
-                               {:term {:search_terms.hakutiedot.pohjakoulutusvaatimukset "pohjakoulutusvaatimuskonfo_am"}}}}}}]
+    (is (= [{:nested
+             {:path "search_terms.hakutiedot"
+              :query {:bool
+                      {:should [{:bool
+                                 {:filter
+                                  {:term {:search_terms.hakutiedot.pohjakoulutusvaatimukset "pohjakoulutusvaatimuskonfo_am"}}}}
+                                {:bool
+                                 {:must_not
+                                  {:exists {:field "search_terms.hakutiedot.pohjakoulutusvaatimukset"}}}}]}}}}]
            (common-filters {:pohjakoulutusvaatimus ["pohjakoulutusvaatimuskonfo_am"]}
                            "2022-08-26T07:21"))))
 
@@ -79,9 +84,13 @@
                                {:bool
                                 {:filter
                                  [{:nested {:path  "search_terms.hakutiedot"
-                                            :query {:bool {:filter
-                                                           {:term {:search_terms.hakutiedot.pohjakoulutusvaatimukset
-                                                                   "pohjakoulutusvaatimuskonfo_am"}}}}}}
+                                            :query {:bool
+                                                    {:should [{:bool
+                                                               {:filter
+                                                                {:term {:search_terms.hakutiedot.pohjakoulutusvaatimukset "pohjakoulutusvaatimuskonfo_am"}}}}
+                                                              {:bool
+                                                               {:must_not
+                                                                {:exists {:field "search_terms.hakutiedot.pohjakoulutusvaatimukset"}}}}]}}}}
                                   {:term {:search_terms.hasJotpaRahoitus true}}]}}
                                :aggs {:real_hits {:reverse_nested {}}}})
                 ((:make-agg jotpa) {:pohjakoulutusvaatimus ["pohjakoulutusvaatimuskonfo_am"]} default-ctx)))))

--- a/test/konfo_backend/search/rajain_definitions_unit_test.clj
+++ b/test/konfo_backend/search/rajain_definitions_unit_test.clj
@@ -106,7 +106,8 @@
                                  :terms
                                  {:field         "search_terms.hakutiedot.pohjakoulutusvaatimukset"
                                   :min_doc_count 0
-                                  :size          1000}}}
+                                  :size          1000
+                                  :missing       "pohjakoulutusvaatimuskonfo_missing"}}}
                                :nested {:path "search_terms.hakutiedot"}})
                 ((:make-agg pohjakoulutusvaatimus) {} default-ctx)))))
 
@@ -121,7 +122,8 @@
                                   {:reverse_nested {}}}
                                  :terms {:field         "search_terms.hakutiedot.pohjakoulutusvaatimukset"
                                          :min_doc_count 0
-                                         :size          1000}}}
+                                         :size          1000
+                                         :missing       "pohjakoulutusvaatimuskonfo_missing"}}}
                                :nested {:path "search_terms.hakutiedot"}}}
                              :filter {:bool {:filter [{:bool {:should [{:term {:search_terms.hasJotpaRahoitus true}}]}}]}}})
               ((:make-agg pohjakoulutusvaatimus) {:jotpa true} default-ctx))))


### PR DESCRIPTION
With pohjakoulutus filter enabled, those education options with no pohjakoulutusvaatimus didn't get returned by the search. Also return those options.